### PR TITLE
feat: improve config file resolution and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,6 +231,21 @@ plot_points = 100
 > [!NOTE]
 > The default baud rate is `9600`. You can customize it in the config file or override it with command-line flags (`--auto`, `--port`/`-p`, `--baud`/`-r`, `--plot`).
 
+### Configuration Precedence
+
+ComChan looks for configuration files in the following order:
+
+1. **Command-line arguments** (Always override config files)
+2. **Specified config file** (via `--config` flag)
+3. **Current directory** (`comchan.toml`)
+4. **Platform-specific config directory**:
+    - Windows: `%APPDATA%\comchan\comchan.toml`
+    - macOS: `~/Library/Application Support/comchan/comchan.toml`
+    - Linux/Unix: `~/.config/comchan/comchan.toml`
+5. **Home directory** (`~/.comchan.toml`)
+
+If multiple configuration files exist, ComChan uses the one with the highest precedence and ignores the others. A warning will be displayed if multiple config files are found to avoid ambiguity.
+
 ---
 
 ## Features


### PR DESCRIPTION
#14

## Description
This PR improves the configuration file resolution logic and documentation.

## Changes
- Modified [find_config_file](cci:1://file:///d:/OSCG/cmp/ComChan/src/main.rs:600:0-650:1) in [src/main.rs](cci:7://file:///d:/OSCG/cmp/ComChan/src/main.rs:0:0-0:0) to scan for all possible configuration files.
- Added a warning message that prints when multiple configuration files are detected, identifying the active file and ignored files.
- Updated [README.md](cci:7://file:///d:/OSCG/cmp/ComChan/README.md:0:0-0:0) to document the configuration file precedence order.
- Updated [generate_default_config](cci:1://file:///d:/OSCG/cmp/ComChan/src/main.rs:667:0-731:1) to include precedence information in the generated config file comments.

## Configuration Precedence
The configuration precedence is now clearly defined as:
1. Command-line arguments
2. Specified config file
3. Current directory
4. Platform-specific directory
5. Home directory

## Testing
- Verified manually by creating multiple config files and confirming the warning is displayed and the correct file is prioritized.