### PR TITLE
feat(simulate): Add simulate option to simulate without hardware

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -270,7 +270,7 @@ checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "comchan"
-version = "0.3.4-alpha"
+version = "0.3.5"
 dependencies = [
  "chrono",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "comchan"
-version = "0.3.4-alpha"
+version = "0.3.5"
 edition = "2024"
 authors = ["Vaishnav Sabari Girish <vaishnav.sabari.girish@gmail.com>"]
 license = "MIT"

--- a/src/config.rs
+++ b/src/config.rs
@@ -21,6 +21,7 @@ pub struct Config {
     pub zephyr: Option<bool>,
     pub export_limit: Option<usize>,
     pub plot_title: Option<String>,
+    pub simulate: Option<bool>,
 }
 
 impl Default for Config {
@@ -41,6 +42,7 @@ impl Default for Config {
             zephyr: Some(false),
             export_limit: Some(1_000_000), // Defaults to 1 million points per sensor
             plot_title: None,
+            simulate: Some(false),
         }
     }
 }
@@ -48,7 +50,7 @@ impl Default for Config {
 #[derive(Parser)]
 #[command(
     name = "comchan",
-    version = "0.3.4-alpha",
+    version = "0.3.5",
     author = "Vaishnav-Sabari-Girish",
     about = "Blazingly Fast Minimal Serial Monitor with Plotting"
 )]
@@ -115,6 +117,9 @@ pub struct Args {
         help = "Set the plot title for the exported SVG file"
     )]
     pub plot_title: Option<String>,
+
+    #[arg(long = "simulate", action = clap::ArgAction::SetTrue, help = "Simulate Serial Data with no need for hardware (Use for testing ComChan)")]
+    pub simulate: bool,
 }
 
 /// The resolved, merged configuration used at runtime.
@@ -135,6 +140,7 @@ pub struct MergedConfig {
     pub zephyr: bool,
     pub export_limit: usize,
     pub plot_title: String,
+    pub simulate: bool,
 }
 
 // ── Platform helpers ─────────────────────────────────────────────────────────
@@ -297,5 +303,6 @@ pub fn merge_config_and_args(config: Config, args: Args) -> MergedConfig {
             .plot_title
             .or(config.plot_title)
             .unwrap_or_else(|| "Sensor Data".to_string()),
+        simulate: args.simulate || config.simulate.unwrap_or(false),
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -53,30 +53,35 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         return list_available_ports();
     }
 
-    let port_name = match &merged.port {
-        Some(p) if p.to_lowercase() == "auto" => match port_finder::find_usb_port()? {
-            Some(detected) => {
-                println!(
-                    "{color_green} Auto-detected USB port: {}{color_reset}",
+    let port_name = if merged.simulate {
+        println!("{color_magenta}Starting in SIMULATE mode....{color_reset}");
+        "SIMULATE_PORT".to_string()
+    } else {
+        match &merged.port {
+            Some(p) if p.to_lowercase() == "auto" => match port_finder::find_usb_port()? {
+                Some(detected) => {
+                    println!(
+                        "{color_green} Auto-detected USB port: {}{color_reset}",
+                        detected
+                    );
                     detected
-                );
-                detected
-            }
+                }
+                None => {
+                    eprintln!(
+                        "{color_red}No USB serial ports found for auto-detection{color_reset}"
+                    );
+                    eprintln!("{color_yellow}Try --list-ports to see available ports{color_reset}");
+                    std::process::exit(1);
+                }
+            },
+            Some(p) => p.clone(),
             None => {
                 eprintln!(
-                    "{color_red}❌ No USB serial ports found for auto-detection{color_reset}"
+                    "{color_red}❌ No port specified. Use --port <PORT>, --auto, or set port in config{color_reset}"
                 );
-                eprintln!("{color_yellow}󰌵 Try --list-ports to see available ports{color_reset}");
+                eprintln!("{color_yellow}󰌵 Try --list-ports or --generate-config{color_reset}");
                 std::process::exit(1);
             }
-        },
-        Some(p) => p.clone(),
-        None => {
-            eprintln!(
-                "{color_red}❌ No port specified. Use --port <PORT>, --auto, or set port in config{color_reset}"
-            );
-            eprintln!("{color_yellow}󰌵 Try --list-ports or --generate-config{color_reset}");
-            std::process::exit(1);
         }
     };
 

--- a/src/monitor.rs
+++ b/src/monitor.rs
@@ -54,29 +54,35 @@ pub fn run_normal_mode(
     let flow_control = parse_flow_control(&config.flow_control)
         .map_err(|e| format!("Configuration error: {}", e))?;
 
-    let mut port = serialport::new(&port_name, config.baud)
-        .timeout(Duration::from_millis(config.timeout_ms))
-        .data_bits(data_bits)
-        .stop_bits(stop_bits)
-        .parity(parity)
-        .flow_control(flow_control)
-        .open()
-        .map_err(|e| format!("Failed to open port {}: {}", port_name, e))?;
+    let mut port = if config.simulate {
+        None
+    } else {
+        Some(
+            serialport::new(&port_name, config.baud)
+                .timeout(Duration::from_millis(config.timeout_ms))
+                .data_bits(data_bits)
+                .stop_bits(stop_bits)
+                .parity(parity)
+                .flow_control(flow_control)
+                .open()
+                .map_err(|e| format!("Failed to open port {}: {}", port_name, e))?,
+        )
+    };
 
-    // Disable DTR
-    let _ = port.write_data_terminal_ready(false);
+    if let Some(p) = port.as_mut() {
+        let _ = p.write_data_terminal_ready(false);
+        thread::sleep(Duration::from_millis(config.reset_delay_ms));
+        let _ = p.write_all(b"\r");
+        let _ = p.flush();
 
-    thread::sleep(Duration::from_millis(config.reset_delay_ms));
-    let _ = port.write_all(b"\r");
-    let _ = port.flush();
-
-    // Zephyr mode
-    if config.zephyr {
-        thread::sleep(Duration::from_millis(100));
-        let _ = port.write_all(b"shell echo off\r");
-        let _ = port.flush();
-        thread::sleep(Duration::from_millis(100));
+        if config.zephyr {
+            thread::sleep(Duration::from_millis(100));
+            let _ = p.write_all(b"shell echo off\r");
+            let _ = p.flush();
+            thread::sleep(Duration::from_millis(100));
+        }
     }
+    // Zephyr mode
 
     let log_writer = if let Some(log_path) = &config.log_file {
         let file = OpenOptions::new()
@@ -170,83 +176,100 @@ pub fn run_normal_mode(
 
     while running.load(std::sync::atomic::Ordering::SeqCst) {
         // ── Read from serial ─────────────────────────────────────────────────
-        match port.read(&mut buffer) {
-            Ok(n) if n > 0 => {
-                let raw = &buffer[..n];
-                let text = String::from_utf8_lossy(raw);
+        if config.simulate {
+            let t = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_secs_f64();
+            let sim_text = format!(
+                "Temperature: {:2}\r\nHumidity: {:.2}\r\nPressure: {:.2}\r\n",
+                (t * 1.0).sin() * 50.0,
+                (t * 0.8).cos() * 50.0,
+                (t * 0.5).sin() * 50.0
+            );
+            io::stdout().write_all(sim_text.as_bytes())?;
+            io::stdout().flush()?;
 
-                // ── Echo suppression ─────────────────────────────────────────
-                // Accumulate into line_acc and check if this chunk is the
-                // echo of the last sent command; if so, swallow it silently.
-                line_acc.push_str(&text);
-                let mut suppress = false;
-                if let Some(ref sent) = last_sent {
-                    let clean_acc = strip_ansi(&line_acc).trim().to_string();
-                    if clean_acc == *sent {
-                        suppress = true;
-                        last_sent = None;
+            thread::sleep(Duration::from_millis(500));
+        } else if let Some(p) = port.as_mut() {
+            match p.read(&mut buffer) {
+                Ok(n) if n > 0 => {
+                    let raw = &buffer[..n];
+                    let text = String::from_utf8_lossy(raw);
+
+                    // ── Echo suppression ─────────────────────────────────────────
+                    // Accumulate into line_acc and check if this chunk is the
+                    // echo of the last sent command; if so, swallow it silently.
+                    line_acc.push_str(&text);
+                    let mut suppress = false;
+                    if let Some(ref sent) = last_sent {
+                        let clean_acc = strip_ansi(&line_acc).trim().to_string();
+                        if clean_acc == *sent {
+                            suppress = true;
+                            last_sent = None;
+                            line_acc.clear();
+                        }
+                    }
+                    if suppress {
+                        continue;
+                    }
+
+                    // ── Verbose timestamp prefix ─────────────────────────────────
+                    // In verbose mode, prepend a timestamp before each line of
+                    // output. We still pass the original bytes through for colour.
+                    if config.verbose {
+                        // Walk the incoming text line by line, printing a timestamp
+                        // before each newline-terminated chunk.
+                        let mut remaining = text.as_ref();
+                        while let Some(pos) = remaining.find('\n') {
+                            let chunk = &remaining[..=pos];
+                            let clean = strip_ansi(chunk);
+                            // Only print timestamp for non-empty lines
+                            if !clean.trim().is_empty() {
+                                print!("[{}] {}", get_timestamp(), chunk);
+                            } else {
+                                print!("{}", chunk);
+                            }
+                            remaining = &remaining[pos + 1..];
+                        }
+                        // Print any trailing partial line (e.g. the prompt)
+                        if !remaining.is_empty() {
+                            print!("{}", remaining);
+                        }
+                    } else {
+                        // Non-verbose: pass raw bytes straight through so Zephyr's
+                        // own ANSI colours and \r\n handling reach the terminal
+                        // untouched.
+                        io::stdout().write_all(raw)?;
+                    }
+                    io::stdout().flush()?;
+
+                    // ── Logging ───────────────────────────────────────────────────
+                    if let Some(ref mut writer) = log_writer {
+                        // Log each complete line
+                        let mut remaining = text.as_ref();
+                        while let Some(pos) = remaining.find('\n') {
+                            let chunk = &remaining[..=pos];
+                            let clean = strip_ansi(chunk);
+                            writeln!(writer, "RX [{}]: {}", get_timestamp(), clean.trim_end())?;
+                            remaining = &remaining[pos + 1..];
+                        }
+                        writer.flush()?;
+                    }
+
+                    // Clear line accumulator once we've seen a full line
+                    if line_acc.contains('\n') {
                         line_acc.clear();
                     }
                 }
-                if suppress {
-                    continue;
-                }
-
-                // ── Verbose timestamp prefix ─────────────────────────────────
-                // In verbose mode, prepend a timestamp before each line of
-                // output. We still pass the original bytes through for colour.
-                if config.verbose {
-                    // Walk the incoming text line by line, printing a timestamp
-                    // before each newline-terminated chunk.
-                    let mut remaining = text.as_ref();
-                    while let Some(pos) = remaining.find('\n') {
-                        let chunk = &remaining[..=pos];
-                        let clean = strip_ansi(chunk);
-                        // Only print timestamp for non-empty lines
-                        if !clean.trim().is_empty() {
-                            print!("[{}] {}", get_timestamp(), chunk);
-                        } else {
-                            print!("{}", chunk);
-                        }
-                        remaining = &remaining[pos + 1..];
+                Ok(_) => {}
+                Err(ref e) if e.kind() == io::ErrorKind::TimedOut => {}
+                Err(e) => {
+                    eprintln!("{color_red}❌ Serial read error: {e}{color_reset}");
+                    if let Some(ref mut writer) = log_writer {
+                        writeln!(writer, "ERROR [{}]: {}", get_timestamp(), e)?;
+                        writer.flush()?;
                     }
-                    // Print any trailing partial line (e.g. the prompt)
-                    if !remaining.is_empty() {
-                        print!("{}", remaining);
-                    }
-                } else {
-                    // Non-verbose: pass raw bytes straight through so Zephyr's
-                    // own ANSI colours and \r\n handling reach the terminal
-                    // untouched.
-                    io::stdout().write_all(raw)?;
-                }
-                io::stdout().flush()?;
-
-                // ── Logging ───────────────────────────────────────────────────
-                if let Some(ref mut writer) = log_writer {
-                    // Log each complete line
-                    let mut remaining = text.as_ref();
-                    while let Some(pos) = remaining.find('\n') {
-                        let chunk = &remaining[..=pos];
-                        let clean = strip_ansi(chunk);
-                        writeln!(writer, "RX [{}]: {}", get_timestamp(), clean.trim_end())?;
-                        remaining = &remaining[pos + 1..];
-                    }
-                    writer.flush()?;
-                }
-
-                // Clear line accumulator once we've seen a full line
-                if line_acc.contains('\n') {
-                    line_acc.clear();
-                }
-            }
-            Ok(_) => {}
-            Err(ref e) if e.kind() == io::ErrorKind::TimedOut => {}
-            Err(e) => {
-                eprintln!("{color_red}❌ Serial read error: {e}{color_reset}");
-                if let Some(ref mut writer) = log_writer {
-                    writeln!(writer, "ERROR [{}]: {}", get_timestamp(), e)?;
-                    writer.flush()?;
                 }
             }
         }
@@ -256,15 +279,18 @@ pub fn run_normal_mode(
             let clean = input.trim_end();
             if !clean.is_empty() {
                 let message = format!("{}\r", clean);
-                if let Err(e) = port.write_all(message.as_bytes()) {
-                    eprintln!("{color_red}❌ Write error: {e}{color_reset}");
-                    if let Some(ref mut writer) = log_writer {
-                        writeln!(writer, "ERROR [{}]: Write error: {}", get_timestamp(), e)?;
-                        writer.flush()?;
+
+                if let Some(p) = port.as_mut() {
+                    if let Err(e) = p.write_all(message.as_bytes()) {
+                        eprintln!("{color_red}❌ Write error: {e}{color_reset}");
+                        if let Some(ref mut writer) = log_writer {
+                            writeln!(writer, "ERROR [{}]: Write error: {}", get_timestamp(), e)?;
+                            writer.flush()?;
+                        }
+                        continue;
                     }
-                    continue;
+                    p.flush()?;
                 }
-                port.flush()?;
 
                 last_sent = Some(clean.to_string());
                 line_acc.clear();
@@ -283,9 +309,11 @@ pub fn run_normal_mode(
         }
 
         // ── Control bytes (e.g. Ctrl+L repaint) ─────────────────────────────
-        if let Ok(byte) = ctrl_rx.try_recv() {
-            let _ = port.write_all(&[byte]);
-            let _ = port.flush();
+        if let Ok(byte) = ctrl_rx.try_recv()
+            && let Some(p) = port.as_mut()
+        {
+            let _ = p.write_all(&[byte]);
+            let _ = p.flush();
         }
 
         thread::sleep(Duration::from_millis(10));

--- a/src/plotter.rs
+++ b/src/plotter.rs
@@ -201,14 +201,19 @@ pub fn run_plotter_mode(
     let parity = parse_parity(&config.parity)?;
     let flow_control = parse_flow_control(&config.flow_control)?;
 
-    let mut port = serialport::new(&port_name, config.baud)
-        .timeout(Duration::from_millis(config.timeout_ms))
-        .data_bits(data_bits)
-        .stop_bits(stop_bits)
-        .parity(parity)
-        .flow_control(flow_control)
-        .open()?;
-
+    let mut port = if config.simulate {
+        None
+    } else {
+        Some(
+            serialport::new(&port_name, config.baud)
+                .timeout(Duration::from_millis(config.timeout_ms))
+                .data_bits(data_bits)
+                .stop_bits(stop_bits)
+                .parity(parity)
+                .flow_control(flow_control)
+                .open()?,
+        )
+    };
     let mut log_writer: Option<BufWriter<std::fs::File>> =
         if let Some(ref log_path) = config.log_file {
             let file = OpenOptions::new()
@@ -276,26 +281,40 @@ pub fn run_plotter_mode(
         }
 
         // ── Serial read ───────────────────────────────────────────────────────
-        match port.read(&mut serial_buf) {
-            Ok(n) if n > 0 => {
-                let chunk = String::from_utf8_lossy(&serial_buf[..n]);
-                state.receive_buf.push_str(&chunk);
+        if config.simulate {
+            let t = state.x * 0.1;
+            let temp = (t * 1.0).sin() * 50.0;
+            let hum = (t * 0.8).cos() * 50.0;
+            let pres = (t * 0.5).sin() * 50.0;
 
-                while let Some(pos) = state.receive_buf.find('\n') {
-                    let line = state.receive_buf.drain(..=pos).collect::<String>();
+            state.ingest_line(&format!("Temperature: {:.2}", temp), config.plot_points);
+            state.ingest_line(&format!("Humidity: {:.2}", hum), config.plot_points);
+            state.ingest_line(&format!("Pressure: {:.2}", pres), config.plot_points);
 
-                    if let Some(ref mut writer) = log_writer {
-                        let _ = writeln!(writer, "RX [{}]: {}", get_timestamp(), line.trim_end());
-                        let _ = writer.flush();
+            std::thread::sleep(Duration::from_millis(50));
+        } else if let Some(p) = port.as_mut() {
+            match p.read(&mut serial_buf) {
+                Ok(n) if n > 0 => {
+                    let chunk = String::from_utf8_lossy(&serial_buf[..n]);
+                    state.receive_buf.push_str(&chunk);
+
+                    while let Some(pos) = state.receive_buf.find('\n') {
+                        let line = state.receive_buf.drain(..=pos).collect::<String>();
+
+                        if let Some(ref mut writer) = log_writer {
+                            let _ =
+                                writeln!(writer, "RX [{}]: {}", get_timestamp(), line.trim_end());
+                            let _ = writer.flush();
+                        }
+
+                        state.ingest_line(&line, config.plot_points);
                     }
-
-                    state.ingest_line(&line, config.plot_points);
                 }
-            }
-            Ok(_) => {}
-            Err(ref e) if e.kind() == io::ErrorKind::TimedOut => {}
-            Err(e) => {
-                state.last_error = Some(format!("Read error: {}", e));
+                Ok(_) => {}
+                Err(ref e) if e.kind() == io::ErrorKind::TimedOut => {}
+                Err(e) => {
+                    state.last_error = Some(format!("Read error: {}", e));
+                }
             }
         }
 


### PR DESCRIPTION
Users can now use the `--simulate` flag to generate simulated data without the need for external hardware to test the tool first.