### PR TITLE
feat(session_replay): Add Session Replay feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -289,7 +289,7 @@ checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "comchan"
-version = "0.3.7"
+version = "0.4.0"
 dependencies = [
  "chrono",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "comchan"
-version = "0.3.7"
+version = "0.4.0"
 edition = "2024"
 authors = ["Vaishnav Sabari Girish <vaishnav.sabari.girish@gmail.com>"]
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ Options:
       --plot-title <PLOT_TITLE>       Set the plot title for the exported SVG file
       --simulate                      Simulate Serial Data with no need for hardware (Use for testing ComChan)
       --csv <CSV_FILE>                Export numeric data to a CSV file while streaming serial data
+      --replay <REPLAY_FILE>          Replay a previous session from its *.log or *.csv file
   -h, --help                          Print help
   -V, --version                       Print version
 ```
@@ -178,6 +179,26 @@ The exported plot will look like this
 comchan -r 115200 --plot --plot-title "Plot Title" --export-limit 5000
 ```
 
+### Session Replay
+
+Replay a previously recorded hardware session in real-time. ComChan will read
+the timestamps and perfectly recreate the timing of the original run. This works
+in both standard monitor and plotter modes!
+
+```bash
+# Replay in standard monitor mode
+comchan --replay test.log
+
+# Replay visually in plotter mode
+comchan --plot --replay sensor_data.csv
+```
+
+> [!IMPORTANT]
+> While you can replay both files, **`.log` files are preferred**. When
+> replaying a `.csv`, ComChan skips the header line, meaning your sensor labels
+> won't be explicitly printed, but they will be plotted (they will default to
+> generic labels like "Channel 0", "Channel 1" in plotter mode).
+
 ### Automatically Detect Serial Ports
 
 Let ComChan find your serial device automatically:
@@ -251,6 +272,7 @@ export_limit = 1000000
 plot_title = "Sensor Data"
 simulate = false
 csv_file = "latest_run.csv"
+replay_file = "test.log"
 ```
 
 ---
@@ -265,6 +287,8 @@ csv_file = "latest_run.csv"
   safely shuts down or reconnects when hardware is unplugged/replugged.
 - **Terminal-Based Serial Plotter** - Visualize multiple sensor values in
   real-time with automatic legends using the `--plot` flag.
+- **Real-Time Session Replay** - Play back previously recorded `.log` or `.csv`
+  files natively to analyze anomalies without needing physical hardware.
 - **Continuous CSV Streaming** - Automatically parse and log numeric sensor data
   into clean, multi-column `.csv` files on-the-fly.
 - **Export Plot to SVG** - Save your visualized serial data as an SVG image,

--- a/src/config.rs
+++ b/src/config.rs
@@ -35,6 +35,7 @@ pub struct Config {
     pub plot_title: Option<String>,
     pub simulate: Option<bool>,
     pub csv_file: Option<String>,
+    pub replay_file: Option<String>,
 }
 
 impl Default for Config {
@@ -57,6 +58,7 @@ impl Default for Config {
             plot_title: None,
             simulate: Some(false),
             csv_file: None,
+            replay_file: None,
         }
     }
 }
@@ -64,7 +66,7 @@ impl Default for Config {
 #[derive(Parser)]
 #[command(
     name = "comchan",
-    version = "0.3.7",
+    version = "0.4.0",
     author = "Vaishnav-Sabari-Girish",
     about = "Blazingly Fast Minimal Serial Monitor with Plotting"
 )]
@@ -143,6 +145,12 @@ pub struct Args {
         help = "Export numeric data to a CSV file while streaming serial data"
     )]
     pub csv_file: Option<String>,
+
+    #[arg(
+        long = "replay",
+        help = "Replay a previous session from its *.log or *.csv file"
+    )]
+    pub replay_file: Option<String>,
 }
 
 /// The resolved, merged configuration used at runtime.
@@ -165,6 +173,7 @@ pub struct MergedConfig {
     pub plot_title: String,
     pub simulate: bool,
     pub csv_file: Option<String>,
+    pub replay_file: Option<String>,
 }
 
 // Generate completions
@@ -347,5 +356,6 @@ pub fn merge_config_and_args(config: Config, args: Args) -> MergedConfig {
             .unwrap_or_else(|| "Sensor Data".to_string()),
         simulate: args.simulate || config.simulate.unwrap_or(false),
         csv_file: args.csv_file.or(config.csv_file),
+        replay_file: args.replay_file.or(config.replay_file),
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,6 +7,7 @@ mod monitor;
 mod parser;
 mod plotter;
 mod port_finder;
+mod replay;
 mod serial;
 
 use config::{
@@ -60,8 +61,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         return list_available_ports();
     }
 
-    let port_name = if merged.simulate {
-        println!("{color_magenta}Starting in SIMULATE mode....{color_reset}");
+    let port_name = if merged.simulate || merged.replay_file.is_some() {
+        println!("{color_magenta}Starting in SIMULATE/REPLAY mode....{color_reset}");
         "SIMULATE_PORT".to_string()
     } else {
         match &merged.port {

--- a/src/monitor.rs
+++ b/src/monitor.rs
@@ -233,7 +233,7 @@ pub fn run_normal_mode(
                         io::stdout().flush().ok();
                     }
                     crate::replay::ReplayEvent::Waiting => {}
-                    crate::replay::ReplayEvent::EOF => {
+                    crate::replay::ReplayEvent::Eof => {
                         println!("\n{color_yellow}Replay Finished.{color_reset}");
                         running.store(false, std::sync::atomic::Ordering::SeqCst);
                         break;

--- a/src/monitor.rs
+++ b/src/monitor.rs
@@ -74,6 +74,15 @@ pub fn run_normal_mode(
         None
     };
 
+    let mut session_replayer = if let Some(ref path) = config.replay_file {
+        Some(
+            crate::replay::SessionReplayer::new(path)
+                .map_err(|e| format!("Failed to open replay file '{}': {}", path, e))?,
+        )
+    } else {
+        None
+    };
+
     println!("{color_green} Listening… (Ctrl+C to exit, Ctrl+L to clear screen){color_reset}\n");
 
     // 2. Setup channels and input thread ONCE
@@ -136,7 +145,7 @@ pub fn run_normal_mode(
 
     // Connection & Reconnection
     while running.load(std::sync::atomic::Ordering::SeqCst) {
-        let mut port = if config.simulate {
+        let mut port = if config.simulate || config.replay_file.is_some() {
             None
         } else {
             // Match handles the error instead of returning it
@@ -215,6 +224,21 @@ pub fn run_normal_mode(
                 }
 
                 thread::sleep(Duration::from_millis(500));
+            } else if let Some(ref mut replayer) = session_replayer {
+                match replayer.next_payload() {
+                    crate::replay::ReplayEvent::Payload(payload) => {
+                        let text = format!("{}\r\n", payload);
+
+                        io::stdout().write_all(text.as_bytes()).ok();
+                        io::stdout().flush().ok();
+                    }
+                    crate::replay::ReplayEvent::Waiting => {}
+                    crate::replay::ReplayEvent::EOF => {
+                        println!("\n{color_yellow}Replay Finished.{color_reset}");
+                        running.store(false, std::sync::atomic::Ordering::SeqCst);
+                        break;
+                    }
+                }
             } else if let Some(p) = port.as_mut() {
                 match p.read(&mut buffer) {
                     Ok(n) if n > 0 => {

--- a/src/plotter.rs
+++ b/src/plotter.rs
@@ -318,7 +318,7 @@ pub fn run_plotter_mode(
                     state.ingest_line(&payload, config.plot_points);
                 }
                 crate::replay::ReplayEvent::Waiting => {}
-                crate::replay::ReplayEvent::EOF => {
+                crate::replay::ReplayEvent::Eof => {
                     std::thread::sleep(Duration::from_millis(100));
                 }
             }

--- a/src/plotter.rs
+++ b/src/plotter.rs
@@ -207,7 +207,7 @@ pub fn run_plotter_mode(
     let parity = parse_parity(&config.parity)?;
     let flow_control = parse_flow_control(&config.flow_control)?;
 
-    let mut port = if config.simulate {
+    let mut port = if config.simulate || config.replay_file.is_some() {
         None
     } else {
         Some(
@@ -237,6 +237,15 @@ pub fn run_plotter_mode(
         .csv_file
         .as_ref()
         .and_then(|path| crate::export::CsvStreamer::new(path).ok());
+
+    let mut session_replayer = if let Some(ref path) = config.replay_file {
+        Some(
+            crate::replay::SessionReplayer::new(path)
+                .map_err(|e| format!("Failed to open replay file '{}' : {}", path, e))?,
+        )
+    } else {
+        None
+    };
 
     let mut state = PlotterState::new(config.export_limit, csv_streamer);
     let mut serial_buf = [0u8; 1024];
@@ -303,6 +312,16 @@ pub fn run_plotter_mode(
             state.ingest_line(&format!("Pressure: {:.2}", pres), config.plot_points);
 
             std::thread::sleep(Duration::from_millis(50));
+        } else if let Some(ref mut replayer) = session_replayer {
+            match replayer.next_payload() {
+                crate::replay::ReplayEvent::Payload(payload) => {
+                    state.ingest_line(&payload, config.plot_points);
+                }
+                crate::replay::ReplayEvent::Waiting => {}
+                crate::replay::ReplayEvent::EOF => {
+                    std::thread::sleep(Duration::from_millis(100));
+                }
+            }
         } else if let Some(p) = port.as_mut() {
             match p.read(&mut serial_buf) {
                 Ok(n) if n > 0 => {
@@ -379,7 +398,7 @@ pub fn run_plotter_mode(
             .filter(|s| s.has_data())
             .map(|sensor| {
                 Dataset::default()
-                    .name(format!("{} ({:.2})", sensor.name, sensor.current_value))
+                    //.name(format!("{} ({:.2})", sensor.name, sensor.current_value))
                     .marker(symbols::Marker::Braille)
                     .graph_type(GraphType::Line)
                     .style(Style::default().fg(sensor.color))
@@ -447,8 +466,7 @@ pub fn run_plotter_mode(
                             y_labels[1].as_str(),
                             y_labels[2].as_str(),
                         ]),
-                )
-                .legend_position(Some(LegendPosition::TopLeft));
+                );
 
             f.render_widget(chart, main_row[0]);
 

--- a/src/replay.rs
+++ b/src/replay.rs
@@ -1,0 +1,107 @@
+use chrono::NaiveTime;
+use std::fs::File;
+use std::io::{BufRead, BufReader};
+use std::time::{Duration, Instant};
+
+pub enum ReplayEvent {
+    Payload(String),
+    Waiting,
+    EOF,
+}
+
+pub struct SessionReplayer {
+    reader: BufReader<File>,
+    last_time: Option<NaiveTime>,
+    is_csv: bool,
+    queued_event: Option<(String, Instant)>,
+}
+
+impl SessionReplayer {
+    pub fn new(filepath: &str) -> std::io::Result<Self> {
+        let file = File::open(filepath)?;
+        let is_csv: bool = filepath.to_lowercase().ends_with(".csv");
+        let mut reader = BufReader::new(file);
+
+        if is_csv {
+            let mut header = String::new();
+            let _ = reader.read_line(&mut header);
+        }
+
+        Ok(Self {
+            reader,
+            last_time: None,
+            is_csv,
+            queued_event: None,
+        })
+    }
+
+    pub fn next_payload(&mut self) -> ReplayEvent {
+        // Check if line is waiting to be printed
+        if let Some((payload, emit_at)) = &self.queued_event {
+            if Instant::now() >= *emit_at {
+                let p = payload.clone();
+                self.queued_event = None;
+                return ReplayEvent::Payload(p);
+            } else {
+                return ReplayEvent::Waiting;
+            }
+        }
+
+        let mut line = String::new();
+
+        while self.reader.read_line(&mut line).unwrap_or(0) > 0 {
+            let trimmed = line.trim();
+            if trimmed.is_empty() {
+                line.clear();
+                continue;
+            }
+
+            let (time_str, payload) = if self.is_csv {
+                let parts: Vec<&str> = trimmed.splitn(2, ',').collect();
+                if parts.len() < 2 {
+                    line.clear();
+                    continue;
+                }
+                (parts[0].trim(), parts[1].trim())
+            } else {
+                if !trimmed.starts_with("RX [") {
+                    line.clear();
+                    continue;
+                }
+
+                let end_bracket = match trimmed.find("]: ") {
+                    Some(idx) => idx,
+                    None => {
+                        line.clear();
+                        continue;
+                    }
+                };
+                (&trimmed[4..end_bracket], &trimmed[end_bracket + 3..])
+            };
+
+            let mut delay_ms = 0;
+            if let Ok(current_time) = NaiveTime::parse_from_str(time_str, "%H:%M:%S%.3f") {
+                if let Some(last) = self.last_time {
+                    let mut ms = current_time.signed_duration_since(last).num_milliseconds();
+                    if ms < 0 {
+                        ms += 24 * 60 * 60 * 1000;
+                    }
+                    if ms > 0 {
+                        delay_ms = ms.min(5000) as u64;
+                    }
+                }
+                self.last_time = Some(current_time);
+            }
+
+            if delay_ms > 0 {
+                let emit_time = Instant::now() + Duration::from_millis(delay_ms);
+                self.queued_event = Some((payload.to_string(), emit_time));
+                return ReplayEvent::Waiting;
+            } else {
+                return ReplayEvent::Payload(payload.to_string());
+            }
+        }
+
+        ReplayEvent::EOF
+    }
+}

--- a/src/replay.rs
+++ b/src/replay.rs
@@ -6,7 +6,7 @@ use std::time::{Duration, Instant};
 pub enum ReplayEvent {
     Payload(String),
     Waiting,
-    EOF,
+    Eof,
 }
 
 pub struct SessionReplayer {
@@ -102,6 +102,6 @@ impl SessionReplayer {
             }
         }
 
-        ReplayEvent::EOF
+        ReplayEvent::Eof
     }
 }


### PR DESCRIPTION
Users can now replay previous sessions from their `.log` or `.csv` files.
This is helpful during presentations in case the hardware has an issue,
but they have logs from their previous sessions.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add Session Replay to `comchan` to play back `.log` or `.csv` sessions with original timing in monitor and plotter modes, so demos can run without hardware. Bumps version to 0.4.0.

- **New Features**
  - Added `--replay <REPLAY_FILE>` flag and `replay_file` config option; reads timestamps and replays pacing from `.log` or `.csv` (`.log` preferred).
  - Works in monitor and plotter; prints lines or feeds the plotter; skips CSV header; uses generic channel labels when needed.
  - Introduced `SessionReplayer` and a SIMULATE/REPLAY path that runs without opening a serial port; updated CLI help and README with usage examples.

- **Refactors**
  - Fixed a clippy warning on EOF handling in `SessionReplayer` for cleaner builds.

<sup>Written for commit 04bcba9f43e3e5facd2c211ff491e3451b7a674e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

