### PR TITLE
Hex dump mode added

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -289,7 +289,7 @@ checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "comchan"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "chrono",
  "clap",
@@ -300,6 +300,7 @@ dependencies = [
  "dirs",
  "inline_colorization",
  "plotters",
+ "pretty-hex",
  "ratatui",
  "serde",
  "serialport",
@@ -1541,6 +1542,12 @@ name = "powerfmt"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
+
+[[package]]
+name = "pretty-hex"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a65843dfefbafd3c879c683306959a6de478443ffe9c9adf02f5976432402d7"
 
 [[package]]
 name = "prettyplease"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "comchan"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2024"
 authors = ["Vaishnav Sabari Girish <vaishnav.sabari.girish@gmail.com>"]
 license = "MIT"
@@ -21,6 +21,7 @@ ctrlc = "3.5"
 dirs = "6.0.0"
 inline_colorization = "0.1.6"
 plotters = "0.3.7"
+pretty-hex = "0.4.2"
 ratatui = "0.30.0"
 serde = { version = "1.0", features = ["derive"] }
 serialport = "4.9"

--- a/README.md
+++ b/README.md
@@ -25,12 +25,14 @@ Choose your preferred installation method:
 ```bash
 # Install from source
 cargo install comchan
+
 ```
 
 Verify the installation:
 
 ```bash
 comchan --version
+
 ```
 
 ### From AUR
@@ -44,6 +46,7 @@ yay -S comchan
 
 # Using paru
 paru -S comchan
+
 ```
 
 ### From source
@@ -53,18 +56,20 @@ Build from source for the latest development version:
 You can do either of the following
 
 ```bash
-cargo install --git https://github.com/Vaishnav-Sabari-Girish/ComChan.git
+cargo install --git [https://github.com/Vaishnav-Sabari-Girish/ComChan.git](https://github.com/Vaishnav-Sabari-Girish/ComChan.git)
+
 ```
 
 OR
 
 ```bash
 # Clone from GitHub
-git clone https://github.com/Vaishnav-Sabari-Girish/ComChan.git
+git clone [https://github.com/Vaishnav-Sabari-Girish/ComChan.git](https://github.com/Vaishnav-Sabari-Girish/ComChan.git)
 
 # Build and run
 cd ComChan
 cargo run --release -- --version
+
 ```
 
 ## CLI Usage
@@ -98,8 +103,11 @@ Options:
       --simulate                      Simulate Serial Data with no need for hardware (Use for testing ComChan)
       --csv <CSV_FILE>                Export numeric data to a CSV file while streaming serial data
       --replay <REPLAY_FILE>          Replay a previous session from its *.log or *.csv file
+  -x, --hex                           Display incoming serial data in raw hex dump format
+      --hex-pretty                    Display incoming serial data in a clean, buffered hex dump format
   -h, --help                          Print help
   -V, --version                       Print version
+
 ```
 
 ---
@@ -114,13 +122,33 @@ Monitor serial output from your device:
 comchan -p <port> -r <baud_rate>
 # OR
 comchan --port <port> --baud <baud_rate>
+
 ```
 
 **Example:**
 
 ```bash
 comchan -p /dev/ttyUSB0 -r 9600
+
 ```
+
+### Hex Dump Mode
+
+Analyze raw binary data from industrial equipment (like Modbus RTU), custom
+SPI/I2C bridge payloads, or corrupted serial transmissions:
+
+```bash
+# Raw Mode: Print incoming fragmented USB bytes exactly as they arrive
+comchan --auto --hex
+
+# Pretty Mode: Buffer the incoming bytes into clean, 16-byte aligned frames
+comchan --auto --hex-pretty
+
+```
+
+> [!NOTE]
+> Both hex dump modes can be safely tested locally by passing the `--simulate`
+> flag!
 
 ### Verbose Mode
 
@@ -129,6 +157,7 @@ timestamps):
 
 ```bash
 comchan -p <port> -r <baud_rate> -v
+
 ```
 
 ### Log Mode
@@ -137,9 +166,10 @@ Save raw serial output to a log file:
 
 ```bash
 comchan -p <port> -r <baud_rate> -l <log_file_name>
+
 ```
 
-[View example log file](./test.log)
+[View example log file](https://www.google.com/search?q=./test.log)
 
 ### CSV Data Streaming
 
@@ -148,12 +178,14 @@ file on-the-fly. This works perfectly alongside both standard and plotter modes.
 
 ```bash
 comchan --auto --baud 115200 --csv sensor_data.csv
+
 ```
 
-[View example CSV file](./sensor_data.csv)
+[View example CSV file](https://www.google.com/search?q=./sensor_data.csv)
 
 > [!NOTE]
-> Works with `--simulate` ([Simulate Mode](#simulate-mode)) too
+> Works with `--simulate`
+> ([Simulate Mode](https://www.google.com/search?q=%23simulate-mode)) too
 
 ### Serial Plotter
 
@@ -161,6 +193,7 @@ Visualize sensor data in real-time, with optional SVG exports:
 
 ```bash
 comchan --port <port> --baud <baud_rate> --plot
+
 ```
 
 *Want to export the plot?*
@@ -170,8 +203,6 @@ comchan -r 115200 --plot    # In the Serial plotter window press CTRL+S
 ```
 
 The exported plot will look like this
-
-![export](./comchan_plot_13-44-08.632.svg)
 
 *Add a title and memory limit (Both are optional):*
 
@@ -219,6 +250,7 @@ Generate autocomplete scripts for your favorite shell (`bash`, `zsh`, `fish`,
 ```bash
 comchan --completions zsh > ~/.zshrc
 comchan --completions nu > ~/.config/nushell/comchan-completions.nu
+
 ```
 
 ### Simulate Mode
@@ -228,6 +260,7 @@ microcontroller plugged in? Use simulate mode to generate mock sensor data!
 
 ```bash
 comchan --simulate --plot
+
 ```
 
 ### Zephyr Shell Mode
@@ -237,6 +270,7 @@ a better interactive experience:
 
 ```bash
 comchan --auto --zephyr
+
 ```
 
 ### Use a Configuration File
@@ -246,6 +280,7 @@ You can use a configuration file instead of command-line flags:
 ```bash
 # Generate default configuration file
 comchan --generate-config
+
 ```
 
 This creates a config file at `~/.config/comchan/comchan.toml` (or
@@ -273,6 +308,8 @@ plot_title = "Sensor Data"
 simulate = false
 csv_file = "latest_run.csv"
 replay_file = "test.log"
+hex_mode = false
+hex_pretty = false
 ```
 
 ---
@@ -281,32 +318,35 @@ replay_file = "test.log"
 
 ### Current Features ✅
 
-- **Read & Write Serial Data** - Monitor incoming data and send commands to your
-  device.
-- **Auto-Recovery & Graceful Exit** - Automatically detects broken pipes and
-  safely shuts down or reconnects when hardware is unplugged/replugged.
-- **Terminal-Based Serial Plotter** - Visualize multiple sensor values in
-  real-time with automatic legends using the `--plot` flag.
-- **Real-Time Session Replay** - Play back previously recorded `.log` or `.csv`
-  files natively to analyze anomalies without needing physical hardware.
-- **Continuous CSV Streaming** - Automatically parse and log numeric sensor data
-  into clean, multi-column `.csv` files on-the-fly.
-- **Export Plot to SVG** - Save your visualized serial data as an SVG image,
-  complete with custom plot titles and memory-safe export limits.
-- **Hardware Simulation** - Test ComChan functionalities and plotting without
-  needing physical hardware connected (`--simulate`).
-- **Zephyr Shell Support** - Dedicated mode for cleanly interacting with Zephyr
-  RTOS shells.
-- **Shell Completions** - Native tab-autocomplete support for Bash, Zsh, Fish,
-  Elvish, PowerShell, and Nushell.
-- **Auto-Detect Serial Ports** - Automatically find connected serial devices
-  (`--auto`).
-- **Configuration Files** - Use `.toml` files instead of typing out long
-  command-line flags every time.
-- **Basic Logging & Local Timestamps** - Save serial output to log files with
-  accurate local time tracking.
-- **Control Codes** - Send `CTRL+L` to clear the screen and nudge the device to
-  redraw prompts natively.
+* **Read & Write Serial Data** - Monitor incoming data and send commands to your
+device.
+* **Auto-Recovery & Graceful Exit** - Automatically detects broken pipes and
+safely shuts down or reconnects when hardware is unplugged/replugged.
+* **Terminal-Based Serial Plotter** - Visualize multiple sensor values in
+real-time with automatic legends using the `--plot` flag.
+* **Real-Time Session Replay** - Play back previously recorded `.log` or `.csv`
+files natively to analyze anomalies without needing physical hardware.
+* **Continuous CSV Streaming** - Automatically parse and log numeric sensor data
+into clean, multi-column `.csv` files on-the-fly.
+* **Hex Dump View** - Inspect raw binary payloads with `--hex` for fragmented
+  USB bus truths, or `--hex-pretty` for perfectly aligned, buffered 16-byte
+  frames.
+* **Export Plot to SVG** - Save your visualized serial data as an SVG image,
+complete with custom plot titles and memory-safe export limits.
+* **Hardware Simulation** - Test ComChan functionalities and plotting without
+needing physical hardware connected (`--simulate`).
+* **Zephyr Shell Support** - Dedicated mode for cleanly interacting with Zephyr
+RTOS shells.
+* **Shell Completions** - Native tab-autocomplete support for Bash, Zsh, Fish,
+Elvish, PowerShell, and Nushell.
+* **Auto-Detect Serial Ports** - Automatically find connected serial devices
+(`--auto`).
+* **Configuration Files** - Use `.toml` files instead of typing out long
+command-line flags every time.
+* **Basic Logging & Local Timestamps** - Save serial output to log files with
+accurate local time tracking.
+* **Control Codes** - Send `CTRL+L` to clear the screen and nudge the device to
+redraw prompts natively.
 
 ## Stargazers over time (Graph)
 
@@ -317,23 +357,11 @@ replay_file = "test.log"
 **This project was NOT vibe-coded BUT AI is still involved in some parts of
 it.**
 
-- **Generating test code:** Because it's something I always skip so I would
-  rather have some AI generated tests than none at all.
-- **Micro-improvements:** I have used AI as an advisor to improve some bits of
-  code here and there. Big refactors or new features are done by my hand though.
-
-<a href="https://brainmade.org/">
-<picture>
-  <source media="(prefers-color-scheme: dark)" srcset="https://brainmade.org/white-logo.svg">
-  <source media="(prefers-color-scheme: light)" srcset="https://brainmade.org/black-logo.svg">
-  <img alt="brainmade" src="https://brainmade.org/white-logo.svg">
-</picture>
-</a>
-
-<div align="center">
+* **Generating test code:** Because it's something I always skip so I would
+rather have some AI generated tests than none at all.
+* **Micro-improvements:** I have used AI as an advisor to improve some bits of
+code here and there. Big refactors or new features are done by my hand though.
 
 Made with ❤️ by the ComChan Community
 
-[⬆ Back to Top](#comchan-communication-channel)
-
-</div>
+[⬆ Back to Top](https://www.google.com/search?q=%23comchan-communication-channel)

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Build from source for the latest development version:
 You can do either of the following
 
 ```bash
-cargo install --git [https://github.com/Vaishnav-Sabari-Girish/ComChan.git](https://github.com/Vaishnav-Sabari-Girish/ComChan.git)
+cargo install --git https://github.com/Vaishnav-Sabari-Girish/ComChan.git
 
 ```
 
@@ -64,7 +64,7 @@ OR
 
 ```bash
 # Clone from GitHub
-git clone [https://github.com/Vaishnav-Sabari-Girish/ComChan.git](https://github.com/Vaishnav-Sabari-Girish/ComChan.git)
+git clone https://github.com/Vaishnav-Sabari-Girish/ComChan.git
 
 # Build and run
 cd ComChan
@@ -169,7 +169,7 @@ comchan -p <port> -r <baud_rate> -l <log_file_name>
 
 ```
 
-[View example log file](https://www.google.com/search?q=./test.log)
+[View example log file](./test.log)
 
 ### CSV Data Streaming
 
@@ -181,11 +181,11 @@ comchan --auto --baud 115200 --csv sensor_data.csv
 
 ```
 
-[View example CSV file](https://www.google.com/search?q=./sensor_data.csv)
+[View example CSV file](./sensor_data.csv)
 
 > [!NOTE]
 > Works with `--simulate`
-> ([Simulate Mode](https://www.google.com/search?q=%23simulate-mode)) too
+> ([Simulate Mode](#simulate-mode)) too
 
 ### Serial Plotter
 
@@ -364,4 +364,4 @@ code here and there. Big refactors or new features are done by my hand though.
 
 Made with ❤️ by the ComChan Community
 
-[⬆ Back to Top](https://www.google.com/search?q=%23comchan-communication-channel)
+[⬆ Back to Top](#comchan-communication-channel)

--- a/src/config.rs
+++ b/src/config.rs
@@ -184,8 +184,8 @@ pub struct MergedConfig {
     pub simulate: bool,
     pub csv_file: Option<String>,
     pub replay_file: Option<String>,
-    pub hex_mode: Option<bool>,
-    pub hex_pretty: Option<bool>,
+    pub hex_mode: bool,
+    pub hex_pretty: bool,
 }
 
 // Generate completions
@@ -369,7 +369,7 @@ pub fn merge_config_and_args(config: Config, args: Args) -> MergedConfig {
         simulate: args.simulate || config.simulate.unwrap_or(false),
         csv_file: args.csv_file.or(config.csv_file),
         replay_file: args.replay_file.or(config.replay_file),
-        hex_mode: args.hex_mode.or(config.hex_mode),
-        hex_pretty: args.hex_pretty.or(config.hex_pretty),
+        hex_mode: args.hex_mode.unwrap_or(false) || config.hex_mode.unwrap_or(false),
+        hex_pretty: args.hex_pretty.unwrap_or(false) || config.hex_pretty.unwrap_or(false),
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -36,6 +36,7 @@ pub struct Config {
     pub simulate: Option<bool>,
     pub csv_file: Option<String>,
     pub replay_file: Option<String>,
+    pub hex_mode: Option<bool>,
 }
 
 impl Default for Config {
@@ -59,6 +60,7 @@ impl Default for Config {
             simulate: Some(false),
             csv_file: None,
             replay_file: None,
+            hex_mode: Some(false),
         }
     }
 }
@@ -66,7 +68,7 @@ impl Default for Config {
 #[derive(Parser)]
 #[command(
     name = "comchan",
-    version = "0.4.0",
+    version = "0.5.0",
     author = "Vaishnav-Sabari-Girish",
     about = "Blazingly Fast Minimal Serial Monitor with Plotting"
 )]
@@ -151,6 +153,9 @@ pub struct Args {
         help = "Replay a previous session from its *.log or *.csv file"
     )]
     pub replay_file: Option<String>,
+
+    #[arg(short = 'x', long = "hex", action = clap::ArgAction::SetTrue, help = "Display incoming serial data in hex dump format")]
+    pub hex_mode: Option<bool>,
 }
 
 /// The resolved, merged configuration used at runtime.
@@ -174,6 +179,7 @@ pub struct MergedConfig {
     pub simulate: bool,
     pub csv_file: Option<String>,
     pub replay_file: Option<String>,
+    pub hex_mode: Option<bool>,
 }
 
 // Generate completions
@@ -357,5 +363,6 @@ pub fn merge_config_and_args(config: Config, args: Args) -> MergedConfig {
         simulate: args.simulate || config.simulate.unwrap_or(false),
         csv_file: args.csv_file.or(config.csv_file),
         replay_file: args.replay_file.or(config.replay_file),
+        hex_mode: args.hex_mode.or(config.hex_mode),
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -37,6 +37,7 @@ pub struct Config {
     pub csv_file: Option<String>,
     pub replay_file: Option<String>,
     pub hex_mode: Option<bool>,
+    pub hex_pretty: Option<bool>,
 }
 
 impl Default for Config {
@@ -61,6 +62,7 @@ impl Default for Config {
             csv_file: None,
             replay_file: None,
             hex_mode: Some(false),
+            hex_pretty: Some(false),
         }
     }
 }
@@ -156,6 +158,9 @@ pub struct Args {
 
     #[arg(short = 'x', long = "hex", action = clap::ArgAction::SetTrue, help = "Display incoming serial data in hex dump format")]
     pub hex_mode: Option<bool>,
+
+    #[arg(long = "hex-pretty", action = clap::ArgAction::SetTrue, help = "Display incoming serial data in a clean, buffered hex-dump format")]
+    pub hex_pretty: Option<bool>,
 }
 
 /// The resolved, merged configuration used at runtime.
@@ -180,6 +185,7 @@ pub struct MergedConfig {
     pub csv_file: Option<String>,
     pub replay_file: Option<String>,
     pub hex_mode: Option<bool>,
+    pub hex_pretty: Option<bool>,
 }
 
 // Generate completions
@@ -364,5 +370,6 @@ pub fn merge_config_and_args(config: Config, args: Args) -> MergedConfig {
         csv_file: args.csv_file.or(config.csv_file),
         replay_file: args.replay_file.or(config.replay_file),
         hex_mode: args.hex_mode.or(config.hex_mode),
+        hex_pretty: args.hex_pretty.or(config.hex_pretty),
     }
 }

--- a/src/monitor.rs
+++ b/src/monitor.rs
@@ -145,8 +145,6 @@ pub fn run_normal_mode(
     let mut lines_discarded = 0;
     const DISCARD_COUNT: usize = 5;
 
-    let mut hex_buf: Vec<u8> = Vec::new();
-
     // Connection & Reconnection
     while running.load(std::sync::atomic::Ordering::SeqCst) {
         let mut port = if config.simulate || config.replay_file.is_some() {
@@ -203,6 +201,7 @@ pub fn run_normal_mode(
         };
 
         let mut is_connected = true;
+        let mut hex_buf: Vec<u8> = Vec::new();
 
         // Read / Write Data
         while running.load(std::sync::atomic::Ordering::SeqCst) && is_connected {
@@ -219,7 +218,7 @@ pub fn run_normal_mode(
                     (t * 0.5).sin() * 50.0
                 );
 
-                if config.hex_mode.unwrap_or(false) {
+                if config.hex_mode || config.hex_pretty {
                     let hex_out = format!("{:?}", sim_text.as_bytes().hex_dump());
                     let raw_mode_safe_hex = hex_out.replace('\n', "\r\n");
                     print!("\r\n{}\r\n", raw_mode_safe_hex);
@@ -256,21 +255,20 @@ pub fn run_normal_mode(
                     Ok(n) if n > 0 => {
                         let raw = &buffer[..n];
 
-                        if config.hex_mode.unwrap_or(false) || config.hex_pretty.unwrap_or(false) {
-                            let (should_print, data_to_print) =
-                                if config.hex_pretty.unwrap_or(false) {
-                                    hex_buf.extend_from_slice(raw);
+                        if config.hex_mode || config.hex_pretty {
+                            let (should_print, data_to_print) = if config.hex_pretty {
+                                hex_buf.extend_from_slice(raw);
 
-                                    if hex_buf.contains(&b'\n') || hex_buf.len() >= 64 {
-                                        let data = hex_buf.clone();
-                                        hex_buf.clear();
-                                        (true, data)
-                                    } else {
-                                        (false, Vec::new())
-                                    }
+                                if hex_buf.contains(&b'\n') || hex_buf.len() >= 64 {
+                                    let data = hex_buf.clone();
+                                    hex_buf.clear();
+                                    (true, data)
                                 } else {
-                                    (true, raw.to_vec())
-                                };
+                                    (false, Vec::new())
+                                }
+                            } else {
+                                (true, raw.to_vec())
+                            };
 
                             if should_print {
                                 let hex_out = format!("{:?}", data_to_print.hex_dump());

--- a/src/monitor.rs
+++ b/src/monitor.rs
@@ -145,6 +145,8 @@ pub fn run_normal_mode(
     let mut lines_discarded = 0;
     const DISCARD_COUNT: usize = 5;
 
+    let mut hex_buf: Vec<u8> = Vec::new();
+
     // Connection & Reconnection
     while running.load(std::sync::atomic::Ordering::SeqCst) {
         let mut port = if config.simulate || config.replay_file.is_some() {
@@ -254,17 +256,34 @@ pub fn run_normal_mode(
                     Ok(n) if n > 0 => {
                         let raw = &buffer[..n];
 
-                        if config.hex_mode.unwrap_or(false) {
-                            let hex_out = format!("{:?}", raw.hex_dump());
+                        if config.hex_mode.unwrap_or(false) || config.hex_pretty.unwrap_or(false) {
+                            let (should_print, data_to_print) =
+                                if config.hex_pretty.unwrap_or(false) {
+                                    hex_buf.extend_from_slice(raw);
 
-                            let raw_mode_safe_hex = hex_out.replace('\n', "\r\n");
+                                    if hex_buf.contains(&b'\n') || hex_buf.len() >= 64 {
+                                        let data = hex_buf.clone();
+                                        hex_buf.clear();
+                                        (true, data)
+                                    } else {
+                                        (false, Vec::new())
+                                    }
+                                } else {
+                                    (true, raw.to_vec())
+                                };
 
-                            print!("\r\n{}\r\n", raw_mode_safe_hex);
-                            io::stdout().flush().ok();
+                            if should_print {
+                                let hex_out = format!("{:?}", data_to_print.hex_dump());
+                                let raw_mode_safe_hex = hex_out.replace('\n', "\r\n");
 
-                            if let Some(ref mut writer) = log_writer {
-                                writeln!(writer, "RX HEX [{}]:\n{}", get_timestamp(), hex_out).ok();
-                                let _ = writer.flush();
+                                print!("\r\n{}\r\n", raw_mode_safe_hex);
+                                io::stdout().flush().ok();
+
+                                if let Some(ref mut writer) = log_writer {
+                                    writeln!(writer, "RX HEX [{}]:\n{}", get_timestamp(), hex_out)
+                                        .ok();
+                                    let _ = writer.flush();
+                                }
                             }
                             continue;
                         }

--- a/src/monitor.rs
+++ b/src/monitor.rs
@@ -14,6 +14,8 @@ use crossterm::{
     terminal,
 };
 
+use pretty_hex::*;
+
 fn strip_ansi(s: &str) -> String {
     let mut out = String::with_capacity(s.len());
 
@@ -214,8 +216,16 @@ pub fn run_normal_mode(
                     (t * 0.8).cos() * 50.0,
                     (t * 0.5).sin() * 50.0
                 );
-                io::stdout().write_all(sim_text.as_bytes()).ok();
-                io::stdout().flush().ok();
+
+                if config.hex_mode.unwrap_or(false) {
+                    let hex_out = format!("{:?}", sim_text.as_bytes().hex_dump());
+                    let raw_mode_safe_hex = hex_out.replace('\n', "\r\n");
+                    print!("\r\n{}\r\n", raw_mode_safe_hex);
+                    io::stdout().flush().ok();
+                } else {
+                    io::stdout().write_all(sim_text.as_bytes()).ok();
+                    io::stdout().flush().ok();
+                }
 
                 if let Some(ref mut streamer) = csv_streamer {
                     let clean = strip_ansi(sim_text.trim());
@@ -243,6 +253,22 @@ pub fn run_normal_mode(
                 match p.read(&mut buffer) {
                     Ok(n) if n > 0 => {
                         let raw = &buffer[..n];
+
+                        if config.hex_mode.unwrap_or(false) {
+                            let hex_out = format!("{:?}", raw.hex_dump());
+
+                            let raw_mode_safe_hex = hex_out.replace('\n', "\r\n");
+
+                            print!("\r\n{}\r\n", raw_mode_safe_hex);
+                            io::stdout().flush().ok();
+
+                            if let Some(ref mut writer) = log_writer {
+                                writeln!(writer, "RX HEX [{}]:\n{}", get_timestamp(), hex_out).ok();
+                                let _ = writer.flush();
+                            }
+                            continue;
+                        }
+
                         let text = String::from_utf8_lossy(raw);
 
                         // ── Echo suppression ─────────────────────────────────────────


### PR DESCRIPTION
This PR adds a hex-dump mode with both raw bytes and pretty printed (To prevent fragmented output)

Closes #60

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a hex dump mode to `comchan` with raw and pretty output to inspect binary serial data. Also fixes hex buffer handling, simulate-mode hex output, and config types; closes #60.

- **New Features**
  - CLI: `-x/--hex` for raw hex dump, `--hex-pretty` for buffered, clean frames.
  - Pretty mode buffers until newline or 64 bytes, then prints 16-byte aligned frames via `pretty-hex`.
  - Config: `hex_mode` and `hex_pretty` supported in `comchan.toml` and `--generate-config`.
  - Logging: writes “RX HEX [timestamp]” blocks; CRLF-safe hex output in terminal.
  - Docs: README and `--help` updated with usage and examples.

- **Bug Fixes**
  - Reset hex buffer on reconnect to prevent stale data leaks.
  - Apply `--hex`/`--hex-pretty` to simulate-mode output.
  - Use raw bools in merged config for `hex_mode` and `hex_pretty` to avoid Option-related issues.

<sup>Written for commit 5247dcffa01758b00bec208b94112e0f8fb48dea. Summary will update on new commits. <a href="https://cubic.dev/pr/Vaishnav-Sabari-Girish/ComChan/pull/63?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

