### PR TITLE
3D rendering using `ratty` with fallback to braille

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -311,6 +311,7 @@ dependencies = [
  "plotters",
  "pretty-hex",
  "ratatui",
+ "ratatui-ratty",
  "ratatui-wireframe",
  "serde",
  "serialport",
@@ -1876,6 +1877,16 @@ checksum = "a7f1342a13e83e4bb9d0b793d0ea762be633f9582048c892ae9041ef39c936f4"
 dependencies = [
  "ratatui-core",
  "ratatui-widgets",
+]
+
+[[package]]
+name = "ratatui-ratty"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a4628ffc4abd26ae6da794639f146c5f3922803a9ad9775054e957371a84dbe"
+dependencies = [
+ "base64",
+ "ratatui-core",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["cli", "embedded-systems", "serial-communication"]
 categories = ["command-line-utilities", "embedded"]
 
 [features]
-default = ["ratty"]
+default = []
 ratty = ["dep:ratatui-ratty"]
 
 [dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["cli", "embedded-systems", "serial-communication"]
 categories = ["command-line-utilities", "embedded"]
 
 [features]
-default = []
+default = ["ratty"]
 ratty = ["dep:ratatui-ratty"]
 
 [dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,10 @@ repository = "https://github.com/Vaishnav-Sabari-Girish/ComChan"
 keywords = ["cli", "embedded-systems", "serial-communication"]
 categories = ["command-line-utilities", "embedded"]
 
+[features]
+default = []
+ratty = ["dep:ratatui-ratty"]
+
 [dependencies]
 chrono = "0.4.44"
 clap = { version = "4.6", features = ["derive"] }
@@ -23,6 +27,7 @@ inline_colorization = "0.1.6"
 plotters = "0.3.7"
 pretty-hex = "0.4.2"
 ratatui = "0.30.0"
+ratatui-ratty = { version = "0.3.0", optional = true }
 ratatui-wireframe = { path = "crates/ratatui-wireframe" }
 serde = { version = "1.0", features = ["derive"] }
 serialport = "4.9"

--- a/README.md
+++ b/README.md
@@ -215,7 +215,9 @@ comchan -r 115200 --plot --plot-title "Plot Title" --export-limit 5000
 ### 3D Spatial Telemetry Dashboard
 
 If you are streaming IMU data (`Pitch`, `Yaw`, and `Roll`), ComChan can render a
-real-time 3D dashboard directly in your terminal.
+real-time 3D dashboard directly in your terminal. The 3D view is equipped with a
+**static global reference frame (X/Y/Z axes)** overlay that remains perfectly
+stationary while your hardware telemetry dictates the object rotation.
 
 While running in `--plot` mode, simply press **`Tab`** or **`2`** to switch from
 the 2D Line Chart to the 3D Telemetry view.
@@ -223,10 +225,12 @@ the 2D Line Chart to the 3D Telemetry view.
 ComChan features a **Graceful Degradation Pipeline** for 3D graphics:
 
 * **GPU-Accelerated 3D:** If compiled with `--features ratty` and run inside the
-  Ratty terminal emulator, it bypasses the standard grid and injects true,
-  shaded 3D `.obj` models via the Ratty Graphics Protocol (RGP).
+  [`ratty`](https://github.com/orhun/ratty) terminal emulator, it bypasses the
+  standard grid and injects true, shaded 3D `.obj` models via the Ratty Graphics
+  Protocol (RGP).
 * **CPU Braille Wireframe:** If running in standard modern terminals (WezTerm,
-  Kitty, Foot, Alacritty), it silently falls back to a zero-dependency,
+  Kitty, Foot, Alacritty)—or if launched inside Ratty *without* the required
+  compile-time feature flag—it safely falls back to a zero-dependency,
   math-driven Braille wireframe rendering engine.
 
 ### Session Replay
@@ -351,9 +355,10 @@ real-time with automatic legends using the `--plot` flag.
   terminal (RGP) for true shaded `.obj` 3D rendering, with a zero-dependency
   CPU-rendered Braille wireframe fallback for standard terminals (WezTerm,
   Kitty, Foot, etc.).
-* **Runtime Terminal Detection** - Automatically detects your terminal emulator
-  to serve the best possible rendering engine and displays it directly in the
-  status bar.
+* **Runtime & Compile-Time Terminal Detection** - Automatically detects your
+  terminal emulator and active feature flags to serve the best possible
+  rendering engine. Accurately reports states like `Ratty (GPU 3D)` or
+  `Ratty (Braille)` directly in the status bar.
 * **Real-Time Session Replay** - Play back previously recorded `.log` or `.csv`
 files natively to analyze anomalies without needing physical hardware.
 * **Continuous CSV Streaming** - Automatically parse and log numeric sensor data

--- a/README.md
+++ b/README.md
@@ -23,9 +23,11 @@ Choose your preferred installation method:
 > The easiest way to install ComChan is via `cargo install`
 
 ```bash
-# Install from source
+# Install from source (Standard Braille Engine)
 cargo install comchan
 
+# Install with Hardware-Accelerated 3D support (Ratty Terminal)
+cargo install comchan --features ratty
 ```
 
 Verify the installation:
@@ -187,7 +189,7 @@ comchan --auto --baud 115200 --csv sensor_data.csv
 > Works with `--simulate`
 > ([Simulate Mode](#simulate-mode)) too
 
-### Serial Plotter
+### Serial Plotter & 2D Graphs
 
 Visualize sensor data in real-time, with optional SVG exports:
 
@@ -209,6 +211,23 @@ The exported plot will look like this
 ```bash
 comchan -r 115200 --plot --plot-title "Plot Title" --export-limit 5000
 ```
+
+### 3D Spatial Telemetry Dashboard
+
+If you are streaming IMU data (`Pitch`, `Yaw`, and `Roll`), ComChan can render a
+real-time 3D dashboard directly in your terminal.
+
+While running in `--plot` mode, simply press **`Tab`** or **`2`** to switch from
+the 2D Line Chart to the 3D Telemetry view.
+
+ComChan features a **Graceful Degradation Pipeline** for 3D graphics:
+
+* **GPU-Accelerated 3D:** If compiled with `--features ratty` and run inside the
+  Ratty terminal emulator, it bypasses the standard grid and injects true,
+  shaded 3D `.obj` models via the Ratty Graphics Protocol (RGP).
+* **CPU Braille Wireframe:** If running in standard modern terminals (WezTerm,
+  Kitty, Foot, Alacritty), it silently falls back to a zero-dependency,
+  math-driven Braille wireframe rendering engine.
 
 ### Session Replay
 
@@ -255,8 +274,9 @@ comchan --completions nu > ~/.config/nushell/comchan-completions.nu
 
 ### Simulate Mode
 
-Want to test ComChan, the Plotter, or CSV Streaming without a physical
-microcontroller plugged in? Use simulate mode to generate mock sensor data!
+Want to test ComChan, the Plotter, the 3D Dashboard, or CSV Streaming without a
+physical microcontroller plugged in? Use simulate mode to generate mock sensor
+data!
 
 ```bash
 comchan --simulate --plot
@@ -324,6 +344,16 @@ device.
 safely shuts down or reconnects when hardware is unplugged/replugged.
 * **Terminal-Based Serial Plotter** - Visualize multiple sensor values in
 real-time with automatic legends using the `--plot` flag.
+* **3D Spatial Telemetry (IMU)** - Visualize Pitch, Yaw, and Roll data in a live
+  3D terminal dashboard equipped with a static global reference frame (X/Y/Z
+  axes).
+* **Hardware-Accelerated 3D & Graceful Fallback** - Native support for the Ratty
+  terminal (RGP) for true shaded `.obj` 3D rendering, with a zero-dependency
+  CPU-rendered Braille wireframe fallback for standard terminals (WezTerm,
+  Kitty, Foot, etc.).
+* **Runtime Terminal Detection** - Automatically detects your terminal emulator
+  to serve the best possible rendering engine and displays it directly in the
+  status bar.
 * **Real-Time Session Replay** - Play back previously recorded `.log` or `.csv`
 files natively to analyze anomalies without needing physical hardware.
 * **Continuous CSV Streaming** - Automatically parse and log numeric sensor data

--- a/src/plotter.rs
+++ b/src/plotter.rs
@@ -26,10 +26,40 @@ use std::time::{Duration, Instant};
 
 use ratatui_wireframe::WireframeWidget;
 
+#[cfg(feature = "ratty")]
+use ratatui_ratty::{ObjectFormat, RattyGraphic, RattyGraphicSettings};
+
 #[derive(PartialEq)]
 enum ActiveTab {
     Chart2D,
     Wireframe3D,
+}
+
+fn detect_terminal() -> String {
+    if std::env::var("TERM_PROGRAM").is_ok_and(|v| v.to_lowercase() == "ratty") {
+        return "Ratty (GPU 3D)".to_string();
+    }
+
+    if std::env::var("WEZTERM_EXECUTABLE").is_ok() {
+        return "WezTerm (Braille)".to_string();
+    }
+
+    // 3. Check Ghostty and Kitty via TERM_PROGRAM
+    if let Ok(prog) = std::env::var("TERM_PROGRAM") {
+        let prog_lower = prog.to_lowercase();
+        if prog_lower == "ghostty" {
+            return "Ghostty (Braille)".to_string();
+        } else if prog_lower == "kitty" {
+            return "Kitty (Braille)".to_string();
+        }
+    }
+
+    // 4. Check Foot via the standard TERM variable
+    if std::env::var("TERM").is_ok_and(|v| v.to_lowercase() == "foot") {
+        return "Foot (Braille)".to_string();
+    }
+
+    "Standard TTY (Braille)".to_string()
 }
 
 // ── Plotter state ─────────────────────────────────────────────────────────────
@@ -57,6 +87,10 @@ struct PlotterState {
     pub export_limit: usize,
     pub csv_streamer: Option<crate::export::CsvStreamer>,
     active_tab: ActiveTab,
+    terminal_type: String,
+
+    #[cfg(feature = "ratty")]
+    ratty_graphic: Option<RattyGraphic<'static>>,
 }
 
 const DISCARD_FIRST_LINES: usize = 3;
@@ -64,6 +98,31 @@ const DISCARD_FIRST_LINES: usize = 3;
 impl PlotterState {
     fn new(export_limit: usize, csv_streamer: Option<crate::export::CsvStreamer>) -> Self {
         let now = Instant::now();
+
+        #[cfg(feature = "ratty")]
+        let ratty_graphic = {
+            let is_ratty = std::env::var("TERM_PROGRAM")
+                .map(|v| v.to_lowercase() == "ratty")
+                .unwrap_or(false);
+
+            if is_ratty {
+                let graphic = RattyGraphic::new(
+                    RattyGraphicSettings::new("cube.obj")
+                        .id(1)
+                        .format(ObjectFormat::Obj)
+                        .scale(0.15)
+                        .depth(3.0)
+                        .brightness(1.5),
+                );
+
+                let obj = b"v -1 -1 1\nv 1 -1 1\nv -1 1 1\nv 1 1 1\nv -1 -1 -1\nv 1 -1 -1\nv -1 1 -1\nv 1 1 -1\nvn 0 0 1\nvn 0 0 -1\nvn 0 1 0\nvn 0 -1 0\nvn 1 0 0\nvn -1 0 0\nf 1//1 2//1 4//1 3//1\nf 5//2 7//2 8//2 6//2\nf 3//3 4//3 8//3 7//3\nf 1//4 5//4 6//4 2//4\nf 2//5 6//5 8//5 4//5\nf 1//6 3//6 7//6 5//6\n";
+                let _ = graphic.register_payload(obj);
+                Some(graphic)
+            } else {
+                None
+            }
+        };
+
         PlotterState {
             sensors: HashMap::new(),
             sensor_order: Vec::new(),
@@ -83,6 +142,10 @@ impl PlotterState {
             export_limit,
             csv_streamer,
             active_tab: ActiveTab::Chart2D,
+            terminal_type: detect_terminal(),
+
+            #[cfg(feature = "ratty")]
+            ratty_graphic,
         }
     }
 
@@ -495,14 +558,26 @@ pub fn run_plotter_mode(
                     let yaw_deg = state.sensors.get("Yaw").map_or(0.0, |s| s.current_value);
                     let roll_deg = state.sensors.get("Roll").map_or(0.0, |s| s.current_value);
 
-                    let pitch = pitch_deg.to_radians();
-                    let yaw = yaw_deg.to_radians();
-                    let roll = roll_deg.to_radians();
+                    let mut _rendered_3d = false;
 
-                    let wireframe = WireframeWidget::new(pitch, yaw, roll)
-                        .title("Rolling 3D Cube")
-                        .color(Color::Green);
-                    f.render_widget(wireframe, main_row[0]);
+                    #[cfg(feature = "ratty")]
+                    if let Some(graphics) = &mut state.ratty_graphic {
+                        graphics.settings_mut().rotation =
+                            [pitch_deg as f32, yaw_deg as f32, roll_deg as f32];
+                        f.render_widget(&*graphics, main_row[0]);
+                        _rendered_3d = true;
+                    }
+
+                    if !_rendered_3d {
+                        let pitch = pitch_deg.to_radians();
+                        let yaw = yaw_deg.to_radians();
+                        let roll = roll_deg.to_radians();
+
+                        let wireframe = WireframeWidget::new(pitch, yaw, roll)
+                            .title("Rolling 3D Cube")
+                            .color(Color::Green);
+                        f.render_widget(wireframe, main_row[0]);
+                    }
                 }
             }
 
@@ -581,6 +656,12 @@ pub fn run_plotter_mode(
                 ),
                 Span::raw("  "),
                 error_span,
+                Span::styled(
+                    format!(" 🖥 {} ", state.terminal_type),
+                    Style::default()
+                        .fg(Color::Magenta)
+                        .add_modifier(Modifier::BOLD),
+                ),
                 Span::styled(
                     "  [Space] pause  [c] clear  [1/2/Tab] views  [q/Esc] quit [Ctrl + s] Export",
                     Style::default().fg(Color::DarkGray),

--- a/src/plotter.rs
+++ b/src/plotter.rs
@@ -90,7 +90,7 @@ struct PlotterState {
     terminal_type: String,
 
     #[cfg(feature = "ratty")]
-    ratty_graphic: Option<RattyGraphic<'static>>,
+    ratty_engines: Option<RattyGraphic<'static>>,
 }
 
 const DISCARD_FIRST_LINES: usize = 3;
@@ -100,23 +100,27 @@ impl PlotterState {
         let now = Instant::now();
 
         #[cfg(feature = "ratty")]
-        let ratty_graphic = {
+        let ratty_engines = {
             let is_ratty = std::env::var("TERM_PROGRAM")
                 .map(|v| v.to_lowercase() == "ratty")
                 .unwrap_or(false);
 
             if is_ratty {
+                // Cube
                 let graphic = RattyGraphic::new(
                     RattyGraphicSettings::new("cube.obj")
                         .id(1)
                         .format(ObjectFormat::Obj)
-                        .scale(0.15)
+                        .scale(0.25)
                         .depth(3.0)
-                        .brightness(1.5),
+                        .brightness(1.8)
+                        .animate(false),
                 );
 
-                let obj = b"v -1 -1 1\nv 1 -1 1\nv -1 1 1\nv 1 1 1\nv -1 -1 -1\nv 1 -1 -1\nv -1 1 -1\nv 1 1 -1\nvn 0 0 1\nvn 0 0 -1\nvn 0 1 0\nvn 0 -1 0\nvn 1 0 0\nvn -1 0 0\nf 1//1 2//1 4//1 3//1\nf 5//2 7//2 8//2 6//2\nf 3//3 4//3 8//3 7//3\nf 1//4 5//4 6//4 2//4\nf 2//5 6//5 8//5 4//5\nf 1//6 3//6 7//6 5//6\n";
+                let obj = b"v -1 -1 1\nv 1 -1 1\nv -1 1 1\nv 1 1 1\nv -1 -1 -1\nv 1 -1 -1\nv -1 1 -1\nv 1 1 -1\nvn 0 0 1\nvn 0 0 -1\nvn 0 1 0\nvn 0 -1 0\nvn 1 0 0\nvn -1 0 0\ns off\nf 1//1 2//1 4//1\nf 1//1 4//1 3//1\nf 6//2 5//2 7//2\nf 6//2 7//2 8//2\nf 3//3 4//3 8//3\nf 3//3 8//3 7//3\nf 5//4 6//4 2//4\nf 5//4 2//4 1//4\nf 2//5 6//5 8//5\nf 2//5 8//5 4//5\nf 5//6 1//6 3//6\nf 5//6 3//6 7//6\n";
                 let _ = graphic.register_payload(obj);
+                let _ = graphic.update();
+
                 Some(graphic)
             } else {
                 None
@@ -145,7 +149,7 @@ impl PlotterState {
             terminal_type: detect_terminal(),
 
             #[cfg(feature = "ratty")]
-            ratty_graphic,
+            ratty_engines,
         }
     }
 
@@ -561,10 +565,90 @@ pub fn run_plotter_mode(
                     let mut _rendered_3d = false;
 
                     #[cfg(feature = "ratty")]
-                    if let Some(graphics) = &mut state.ratty_graphic {
-                        graphics.settings_mut().rotation =
-                            [pitch_deg as f32, yaw_deg as f32, roll_deg as f32];
-                        f.render_widget(&*graphics, main_row[0]);
+                    if let Some(main_cube) = &mut state.ratty_engines {
+                        let rot = [pitch_deg as f32, yaw_deg as f32, roll_deg as f32];
+                        main_cube.settings_mut().rotation = rot;
+                        f.render_widget(&*main_cube, main_row[0]);
+
+                        // Static canvas gnomon — identical to WireframeWidget's axes, no rotation
+                        let gnomon_area = {
+                            let area = main_row[0];
+                            let g_width = 18u16;
+                            let g_height = 9u16;
+                            ratatui::layout::Rect {
+                                x: area.x + area.width.saturating_sub(g_width + 2),
+                                y: area.y + area.height.saturating_sub(g_height + 1),
+                                width: g_width.min(area.width),
+                                height: g_height.min(area.height),
+                            }
+                        };
+
+                        f.render_widget(ratatui::widgets::Clear, gnomon_area);
+
+                        let gnomon_canvas = ratatui::widgets::canvas::Canvas::default()
+                            .block(
+                                Block::default()
+                                    .borders(Borders::ALL)
+                                    .border_style(Style::default().fg(Color::DarkGray)),
+                            )
+                            .marker(ratatui::symbols::Marker::Braille)
+                            .x_bounds([-5.0, 5.0])
+                            .y_bounds([-5.0, 5.0])
+                            .paint(|ctx| {
+                                let p_origin = (0.0, 0.0);
+                                let p_x = (4.0, 0.0);
+                                let p_y = (0.0, 3.5);
+                                let p_z = (-2.8, -2.8);
+
+                                ctx.draw(&ratatui::widgets::canvas::Line {
+                                    x1: p_origin.0,
+                                    y1: p_origin.1,
+                                    x2: p_x.0,
+                                    y2: p_x.1,
+                                    color: Color::Red,
+                                });
+                                ctx.draw(&ratatui::widgets::canvas::Line {
+                                    x1: p_origin.0,
+                                    y1: p_origin.1,
+                                    x2: p_y.0,
+                                    y2: p_y.1,
+                                    color: Color::Yellow,
+                                });
+                                ctx.draw(&ratatui::widgets::canvas::Line {
+                                    x1: p_origin.0,
+                                    y1: p_origin.1,
+                                    x2: p_z.0,
+                                    y2: p_z.1,
+                                    color: Color::LightBlue,
+                                });
+
+                                ctx.print(
+                                    p_x.0 + 0.2,
+                                    p_x.1,
+                                    ratatui::text::Span::styled(
+                                        "X",
+                                        Style::default().fg(Color::Red),
+                                    ),
+                                );
+                                ctx.print(
+                                    p_y.0,
+                                    p_y.1 + 0.2,
+                                    ratatui::text::Span::styled(
+                                        "Y",
+                                        Style::default().fg(Color::Yellow),
+                                    ),
+                                );
+                                ctx.print(
+                                    p_z.0 - 0.5,
+                                    p_z.1 - 0.5,
+                                    ratatui::text::Span::styled(
+                                        "Z",
+                                        Style::default().fg(Color::LightBlue),
+                                    ),
+                                );
+                            });
+
+                        f.render_widget(gnomon_canvas, gnomon_area);
                         _rendered_3d = true;
                     }
 

--- a/src/plotter.rs
+++ b/src/plotter.rs
@@ -44,7 +44,6 @@ fn detect_terminal() -> String {
         return "WezTerm (Braille)".to_string();
     }
 
-    // 3. Check Ghostty and Kitty via TERM_PROGRAM
     if let Ok(prog) = std::env::var("TERM_PROGRAM") {
         let prog_lower = prog.to_lowercase();
         if prog_lower == "ghostty" {
@@ -54,7 +53,6 @@ fn detect_terminal() -> String {
         }
     }
 
-    // 4. Check Foot via the standard TERM variable
     if std::env::var("TERM").is_ok_and(|v| v.to_lowercase() == "foot") {
         return "Foot (Braille)".to_string();
     }
@@ -493,7 +491,6 @@ pub fn run_plotter_mode(
             .filter(|s| s.has_data())
             .map(|sensor| {
                 Dataset::default()
-                    //.name(format!("{} ({:.2})", sensor.name, sensor.current_value))
                     .marker(symbols::Marker::Braille)
                     .graph_type(GraphType::Line)
                     .style(Style::default().fg(sensor.color))
@@ -555,6 +552,23 @@ pub fn run_plotter_mode(
                         );
 
                     f.render_widget(chart, main_row[0]);
+
+                    // ── The Fix: Clear the GPU graphic ──
+                    #[cfg(feature = "ratty")]
+                    if let Some(graphic) = &mut state.ratty_engines {
+                        // By rendering the hardware graphic into an empty 0x0 Area when not in 3D mode,
+                        // we force the terminal engine to erase it so it doesn't bleed into the chart.
+                        graphic.settings_mut().scale = 0.0;
+                        f.render_widget(
+                            &*graphic,
+                            ratatui::layout::Rect {
+                                x: main_row[0].x,
+                                y: main_row[0].y,
+                                width: 1,
+                                height: 1,
+                            },
+                        );
+                    }
                 }
 
                 ActiveTab::Wireframe3D => {
@@ -567,6 +581,7 @@ pub fn run_plotter_mode(
                     #[cfg(feature = "ratty")]
                     if let Some(main_cube) = &mut state.ratty_engines {
                         let rot = [pitch_deg as f32, yaw_deg as f32, roll_deg as f32];
+                        main_cube.settings_mut().scale = 0.25;
                         main_cube.settings_mut().rotation = rot;
                         f.render_widget(&*main_cube, main_row[0]);
 

--- a/src/plotter.rs
+++ b/src/plotter.rs
@@ -37,7 +37,11 @@ enum ActiveTab {
 
 fn detect_terminal() -> String {
     if std::env::var("TERM_PROGRAM").is_ok_and(|v| v.to_lowercase() == "ratty") {
-        return "Ratty (GPU 3D)".to_string();
+        return if cfg!(feature = "ratty") {
+            "Ratty (GPU 3D)".to_string()
+        } else {
+            "Ratty (Braille)".to_string()
+        };
     }
 
     if std::env::var("WEZTERM_EXECUTABLE").is_ok() {


### PR DESCRIPTION
This PR adds the 3D rendering using `ratatui-ratty` which uses the **Ratty Graphics Protocol (RGP)** to render 3D objects directly in the terminal.
It also adds a failsafe wherein if any terminal other than `ratty` is used, t falls back to the default braille rendering.

Closes #65

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds GPU-accelerated 3D rendering via `ratatui-ratty` behind an optional `ratty` feature, with automatic fallback to Braille wireframe. Corrects rendering mode detection to respect the `ratty` feature and fixes cube ghosting when switching tabs.

- **New Features**
  - Optional `ratty` feature integrates `ratatui-ratty` (off by default).
  - Runtime terminal detection (Ratty, WezTerm, Ghostty, Kitty, Foot) with status bar display.
  - Graceful fallback: Ratty (RGP) 3D → `ratatui-wireframe` Braille.
  - Gnomon (XYZ axes) overlay and improved cube shading.

- **Bug Fixes**
  - Clear the Ratty GPU graphic when leaving the 3D tab to prevent ghosting in 2D charts.
  - Accurate mode reporting: shows “Ratty (Braille)” when compiled without the `ratty` feature, even inside Ratty.

<sup>Written for commit 050e5e42033df2f8b76a39c26ed39ad230783ad6. Summary will update on new commits. <a href="https://cubic.dev/pr/Vaishnav-Sabari-Girish/ComChan/pull/66?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

