### PR TITLE
feat(zephyr_logs): Supports plotting from Zephyr Logs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -289,7 +289,7 @@ checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "comchan"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "chrono",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "comchan"
-version = "0.6.0"
+version = "0.7.0"
 edition = "2024"
 authors = ["Vaishnav Sabari Girish <vaishnav.sabari.girish@gmail.com>"]
 license = "MIT"

--- a/src/config.rs
+++ b/src/config.rs
@@ -70,7 +70,7 @@ impl Default for Config {
 #[derive(Parser)]
 #[command(
     name = "comchan",
-    version = "0.6.0",
+    version = "0.7.0",
     author = "Vaishnav-Sabari-Girish",
     about = "Blazingly Fast Minimal Serial Monitor with Plotting"
 )]

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -82,7 +82,10 @@ pub fn parse_sensor_data<'a>(line: &'a str) -> Vec<(Cow<'a, str>, f64)> {
 
     // ── Pattern 0: Zephyr Log format (Specific) ──
     // Look specifically for the log signature to avoid "greedy" colon matching
-    let is_zephyr_log = line.contains("<inf>") || line.contains("<err>") || line.contains("<wrn>");
+    let is_zephyr_log = line.contains("<inf>")
+        || line.contains("<err>")
+        || line.contains("<wrn>")
+        || line.contains("<dbg>");
     if is_zephyr_log && let Some(pos) = line.find("> ") {
         let working_line = &line[pos + 2..];
         // Only split at the LAST colon if it's followed by a number

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -86,7 +86,9 @@ pub fn parse_sensor_data<'a>(line: &'a str) -> Vec<(Cow<'a, str>, f64)> {
         working_line = &line[pos + 2..];
     }
 
-    if let Some(colon_pos) = working_line.rfind(':') {
+    if line.find("> ").is_some()
+        && let Some(colon_pos) = working_line.rfind(':')
+    {
         let (label, val_part) = working_line.split_at(colon_pos);
 
         // Split the logger name

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -80,27 +80,23 @@ pub fn parse_sensor_data<'a>(line: &'a str) -> Vec<(Cow<'a, str>, f64)> {
     let mut results = Vec::new();
     let line = line.trim();
 
-    // Zephyr Log format
-    let mut working_line = line;
-    if let Some(pos) = line.find("> ") {
-        working_line = &line[pos + 2..];
-    }
+    // ── Pattern 0: Zephyr Log format (Specific) ──
+    // Look specifically for the log signature to avoid "greedy" colon matching
+    let is_zephyr_log = line.contains("<inf>") || line.contains("<err>") || line.contains("<wrn>");
+    if is_zephyr_log && let Some(pos) = line.find("> ") {
+        let working_line = &line[pos + 2..];
+        // Only split at the LAST colon if it's followed by a number
+        if let Some(colon_pos) = working_line.rfind(':') {
+            let (label, val_part) = working_line.split_at(colon_pos);
+            let val_str = val_part[1..].trim();
+            let numeric_part = val_str.split_whitespace().next().unwrap_or(val_str);
 
-    if line.find("> ").is_some()
-        && let Some(colon_pos) = working_line.rfind(':')
-    {
-        let (label, val_part) = working_line.split_at(colon_pos);
-
-        // Split the logger name
-        let clean_label = label.split(':').next_back().unwrap_or(label).trim();
-
-        let val_str = val_part[1..].trim();
-
-        let numeric_part = val_str.split_whitespace().next().unwrap_or(val_str);
-
-        if let Ok(val) = numeric_part.parse::<f64>() {
-            results.push((Cow::Owned(clean_label.to_string()), val));
-            return results;
+            if let Ok(val) = numeric_part.parse::<f64>() {
+                // Extract the actual sensor label by taking the part after the last internal colon
+                let clean_label = label.split(':').next_back().unwrap_or(label).trim();
+                results.push((Cow::Owned(clean_label.to_string()), val));
+                return results;
+            }
         }
     }
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -80,6 +80,28 @@ pub fn parse_sensor_data<'a>(line: &'a str) -> Vec<(Cow<'a, str>, f64)> {
     let mut results = Vec::new();
     let line = line.trim();
 
+    // Zephyr Log format
+    let mut working_line = line;
+    if let Some(pos) = line.find("> ") {
+        working_line = &line[pos + 2..];
+    }
+
+    if let Some(colon_pos) = working_line.rfind(':') {
+        let (label, val_part) = working_line.split_at(colon_pos);
+
+        // Split the logger name
+        let clean_label = label.split(':').next_back().unwrap_or(label).trim();
+
+        let val_str = val_part[1..].trim();
+
+        let numeric_part = val_str.split_whitespace().next().unwrap_or(val_str);
+
+        if let Ok(val) = numeric_part.parse::<f64>() {
+            results.push((Cow::Owned(clean_label.to_string()), val));
+            return results;
+        }
+    }
+
     // ── Pattern 1: Comma-separated multiple items ──
     // Handles: "Mag: 45, Gyro: 12" OR "Mag=45, Gyro=12" OR "45, 12"
     if line.contains(',') {


### PR DESCRIPTION
This PR adds support for plotting logs from Zephyr RTOS. 

Zephyr RTOS logs usually come like this 

```text
*** Booting Zephyr OS build v4.4.0-313-g4e7fcbb2d84d ***
[00:00:00.000,784] <inf> sensor_logger: Successfully initialized p3t1755@4800000236152a0090
[00:00:00.000,868] <inf> sensor_logger: Ambient Temperature: 30.937500 C
[00:00:01.001,000] <inf> sensor_logger: Ambient Temperature: 30.875000 C
[00:00:02.001,300] <inf> sensor_logger: Ambient Temperature: 30.875000 C
[00:00:03.001,497] <inf> sensor_logger: Ambient Temperature: 30.875000 C
[00:00:04.001,801] <inf> sensor_logger: Ambient Temperature: 30.875000 C
[00:00:05.001,997] <inf> sensor_logger: Ambient Temperature: 30.875000 C
[00:00:06.002,300] <inf> sensor_logger: Ambient Temperature: 30.875000 C
```

So this caused issues in plotting data. 

Closes #68

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds support for parsing Zephyr RTOS logs so sensor values plot correctly, including `<dbg>` debug entries. The parser trims the timestamp/level, drops the logger name, keeps the last field label, and reads the first number after the last colon (ignoring units); plus parser style cleanups and bumps `comchan` to `0.7.0`.

<sup>Written for commit 1a7f6603999b93967901b4a9600c5e5fe2f40e38. Summary will update on new commits. <a href="https://cubic.dev/pr/Vaishnav-Sabari-Girish/ComChan/pull/69?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

