### PR TITLE
Add no_std support for ratatui-wireframe 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1736,9 +1736,10 @@ dependencies = [
 
 [[package]]
 name = "ratatui-wireframe"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "ratatui",
+ "spin",
  "wrfm",
 ]
 
@@ -1988,6 +1989,15 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
+name = "spin"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1527984ca054dfca79333baec451042863f485fbee01b7bf6d911de915cac865"
+dependencies = [
+ "lock_api",
+]
 
 [[package]]
 name = "static_assertions"
@@ -2786,9 +2796,9 @@ dependencies = [
 
 [[package]]
 name = "wrfm"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3bec53669720b4b9c2a4a40102c5b86cc0b2cb6253e6a99a5cdc77bc20ba2c81"
+checksum = "d8d67316c98c974f25c91ef05c9110edad3543f034572a688de7d67c2c746bdf"
 
 [[package]]
 name = "yeslogic-fontconfig-sys"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -289,7 +289,7 @@ checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "comchan"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "chrono",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1094,6 +1094,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "libm"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
+
+[[package]]
 name = "libredox"
 version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1305,6 +1311,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -1738,6 +1745,7 @@ dependencies = [
 name = "ratatui-wireframe"
 version = "0.6.0"
 dependencies = [
+ "num-traits",
  "ratatui",
  "spin",
  "wrfm",
@@ -1995,9 +2003,6 @@ name = "spin"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1527984ca054dfca79333baec451042863f485fbee01b7bf6d911de915cac865"
-dependencies = [
- "lock_api",
-]
 
 [[package]]
 name = "static_assertions"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "comchan"
-version = "0.7.0"
+version = "0.7.1"
 edition = "2024"
 authors = ["Vaishnav Sabari Girish <vaishnav.sabari.girish@gmail.com>"]
 license = "MIT"
@@ -28,11 +28,11 @@ plotters = "0.3.7"
 pretty-hex = "0.4.2"
 ratatui = "0.30.0"
 ratatui-ratty = { version = "0.3.0", optional = true }
-ratatui-wireframe = { version = "0.5.0", path = "crates/ratatui-wireframe" }
+ratatui-wireframe = { version = "0.6.0", path = "crates/ratatui-wireframe" }
 serde = { version = "1.0", features = ["derive"] }
 serialport = "4.9"
 toml = "1.1.2"
-wrfm = "0.3.0"
+wrfm = "0.4.0"
 
 [workspace]
 members = [

--- a/crates/ratatui-wireframe/Cargo.toml
+++ b/crates/ratatui-wireframe/Cargo.toml
@@ -12,10 +12,11 @@ keywords = ["tui", "embedded-systems", "serial-communication"]
 categories = ["command-line-utilities", "embedded"]
 
 [dependencies]
+num-traits = { version = "0.2.19", default-features = false, features = ["libm"] }
 ratatui = { version = "0.30.0", default-features = false }
-spin = "0.12.0"
+spin = { version = "0.12.0", default-features = false, features = ["once"] }
 wrfm = { version = "0.4.0", default-features = false }
 
 [features]
 default = ["std"]
-std = []
+std = ["ratatui/layout-cache"]

--- a/crates/ratatui-wireframe/Cargo.toml
+++ b/crates/ratatui-wireframe/Cargo.toml
@@ -15,3 +15,7 @@ categories = ["command-line-utilities", "embedded"]
 ratatui = "0.30.0"
 spin = "0.12.0"
 wrfm = { version = "0.4.0", default-features = false }
+
+[features]
+default = ["std"]
+std = []

--- a/crates/ratatui-wireframe/Cargo.toml
+++ b/crates/ratatui-wireframe/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["tui", "embedded-systems", "serial-communication"]
 categories = ["command-line-utilities", "embedded"]
 
 [dependencies]
-ratatui = "0.30.0"
+ratatui = { version = "0.30.0", default-features = false }
 spin = "0.12.0"
 wrfm = { version = "0.4.0", default-features = false }
 

--- a/crates/ratatui-wireframe/Cargo.toml
+++ b/crates/ratatui-wireframe/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ratatui-wireframe"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2024"
 authors = ["Vaishnav Sabari Girish <vaishnav.sabari.girish@gmail.com>"]
 license = "MIT"
@@ -13,4 +13,5 @@ categories = ["command-line-utilities", "embedded"]
 
 [dependencies]
 ratatui = "0.30.0"
-wrfm = "0.3.0"
+spin = "0.12.0"
+wrfm = { version = "0.4.0", default-features = false }

--- a/crates/ratatui-wireframe/src/lib.rs
+++ b/crates/ratatui-wireframe/src/lib.rs
@@ -1,3 +1,6 @@
+#![no_std]
+extern crate alloc;
+
 pub mod model;
 pub mod widget;
 

--- a/crates/ratatui-wireframe/src/model.rs
+++ b/crates/ratatui-wireframe/src/model.rs
@@ -1,4 +1,5 @@
-use std::sync::OnceLock;
+use crate::alloc::vec::Vec;
+use spin::Once;
 use wrfm::WrfmModel;
 
 /// Represents a 3D wireframe model consisting of vertices and edges.
@@ -17,9 +18,9 @@ impl Model {
     }
 
     pub fn cube() -> &'static Self {
-        static CUBE: OnceLock<Model> = OnceLock::new();
+        static CUBE: Once<Model> = Once::new();
 
-        CUBE.get_or_init(|| {
+        CUBE.call_once(|| {
             let cube_data = include_str!("./models/cube.wrfm");
             let wrfm = WrfmModel::from_str("cube", cube_data).unwrap();
             Self::from_wrfm(wrfm)
@@ -27,9 +28,9 @@ impl Model {
     }
 
     pub fn tetrahedron() -> &'static Self {
-        static TETRAHEDRON: OnceLock<Model> = OnceLock::new();
+        static TETRAHEDRON: Once<Model> = Once::new();
 
-        TETRAHEDRON.get_or_init(|| {
+        TETRAHEDRON.call_once(|| {
             let tetra_data = include_str!("./models/tetrahedron.wrfm");
             let wrfm = WrfmModel::from_str("tetrahedron", tetra_data).unwrap();
             Self::from_wrfm(wrfm)
@@ -37,9 +38,9 @@ impl Model {
     }
 
     pub fn octahedron() -> &'static Self {
-        static OCTAHEDRON: OnceLock<Model> = OnceLock::new();
+        static OCTAHEDRON: Once<Model> = Once::new();
 
-        OCTAHEDRON.get_or_init(|| {
+        OCTAHEDRON.call_once(|| {
             let octa_data = include_str!("./models/octahedron.wrfm");
             let wrfm = WrfmModel::from_str("octahedron", octa_data).unwrap();
             Self::from_wrfm(wrfm)

--- a/crates/ratatui-wireframe/src/widget.rs
+++ b/crates/ratatui-wireframe/src/widget.rs
@@ -1,6 +1,9 @@
+// Only import the software math trait when compiling for bare-metal (no_std)
 use crate::model::Model;
 use alloc::string::{String, ToString};
 use alloc::vec::Vec;
+#[cfg(not(feature = "std"))]
+use num_traits::Float;
 use ratatui::{
     buffer::Buffer,
     layout::Rect,

--- a/crates/ratatui-wireframe/src/widget.rs
+++ b/crates/ratatui-wireframe/src/widget.rs
@@ -1,4 +1,6 @@
 use crate::model::Model;
+use alloc::string::{String, ToString};
+use alloc::vec::Vec;
 use ratatui::{
     buffer::Buffer,
     layout::Rect,

--- a/crates/ratatui-wireframe/src/widget.rs
+++ b/crates/ratatui-wireframe/src/widget.rs
@@ -70,10 +70,18 @@ impl<'a> Widget for WireframeWidget<'a> {
             rotated.push((x3, y3, z2));
         }
 
-        // Calculate dynamic aspect ratio to prevent stretching
-        let aspect = (area.width as f64) / ((area.height as f64) * 2.0);
         let y_extent = 4.0;
-        let x_extent = aspect * y_extent;
+
+        // Desktop (std): Dynamically calculate aspect ratio based on terminal resize
+        #[cfg(feature = "std")]
+        let x_extent = {
+            let aspect = (area.width as f64) / ((area.height as f64) * 2.0);
+            aspect * y_extent
+        };
+
+        // Embedded (no_std): Hardcode the aspect ratio to squish the 1:2 Braille font
+        #[cfg(not(feature = "std"))]
+        let x_extent = y_extent * 2.0;
 
         let canvas = Canvas::default()
             .block(Block::default().borders(Borders::ALL).title(self.title))


### PR DESCRIPTION
`ratatui-wireframe` will now have no_std support 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds no_std support to `ratatui-wireframe`, fixes trig under no_std with `num-traits` + `libm`, and gates canvas behavior by feature flags. Disables `ratatui` defaults, adds a `std` feature, and bumps versions (`ratatui-wireframe` v0.6.0, workspace `comchan` v0.7.1).

- **New Features**
  - Marked crate `#![no_std]`, enabled `extern crate alloc`, and added a default `std` feature (enables `ratatui/layout-cache`).
  - Replaced `std::sync::OnceLock` with `spin::Once`; switched modules to `alloc` types and `num-traits::Float` (with `libm`) for trig under no_std.
  - Feature-gated canvas: dynamic aspect ratio when `std`; fixed 1:2 ratio under no_std to match Braille cells.

- **Dependencies**
  - Added `spin` and `num-traits` (with `libm`); disabled default features for `ratatui` and `wrfm` (now `0.4.0`).
  - Bumped `ratatui-wireframe` to `0.6.0` and workspace `comchan` to `0.7.1`.

<sup>Written for commit b5702396a090e9bfe815b62889f1eb73b7e5828d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Vaishnav-Sabari-Girish/ComChan/pull/82?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

