### PR TITLE
feat(smooth): Smoother 3D telemetry viewer.

### DIFF
--- a/src/plotter.rs
+++ b/src/plotter.rs
@@ -469,7 +469,15 @@ pub fn run_plotter_mode(
             }
         } else if let Some(p) = port.as_mut() {
             // DRAIN LOOP: Pull all available data from the OS buffer before rendering
+            let mut drain_iters = 0;
+            const MAX_DRAIN_SIZE: usize = 10; // 10 iterations * 1024 byte = 10kB max per frame
+
             loop {
+                if drain_iters >= MAX_DRAIN_SIZE {
+                    break;
+                }
+
+                drain_iters += 1;
                 match p.bytes_to_read() {
                     Ok(avail) if avail > 0 => match p.read(&mut serial_buf) {
                         Ok(n) if n > 0 => {

--- a/src/plotter.rs
+++ b/src/plotter.rs
@@ -93,6 +93,12 @@ struct PlotterState {
 
     custom_model: Option<ratatui_wireframe::model::Model>,
 
+    // Interpolation state
+    display_pitch: f64,
+    display_yaw: f64,
+    display_roll: f64,
+    last_frame_time: Instant,
+
     #[cfg(feature = "ratty")]
     ratty_engines: Option<RattyGraphic<'static>>,
 }
@@ -174,6 +180,11 @@ impl PlotterState {
             active_tab: ActiveTab::Chart2D,
             terminal_type: detect_terminal(),
             custom_model: None,
+
+            display_pitch: 0.0,
+            display_yaw: 0.0,
+            display_roll: 0.0,
+            last_frame_time: now,
 
             #[cfg(feature = "ratty")]
             ratty_engines,
@@ -457,30 +468,63 @@ pub fn run_plotter_mode(
                 }
             }
         } else if let Some(p) = port.as_mut() {
-            match p.read(&mut serial_buf) {
-                Ok(n) if n > 0 => {
-                    let chunk = String::from_utf8_lossy(&serial_buf[..n]);
-                    state.receive_buf.push_str(&chunk);
+            // DRAIN LOOP: Pull all available data from the OS buffer before rendering
+            loop {
+                match p.bytes_to_read() {
+                    Ok(avail) if avail > 0 => match p.read(&mut serial_buf) {
+                        Ok(n) if n > 0 => {
+                            let chunk = String::from_utf8_lossy(&serial_buf[..n]);
+                            state.receive_buf.push_str(&chunk);
 
-                    while let Some(pos) = state.receive_buf.find('\n') {
-                        let line = state.receive_buf.drain(..=pos).collect::<String>();
+                            while let Some(pos) = state.receive_buf.find('\n') {
+                                let line = state.receive_buf.drain(..=pos).collect::<String>();
 
-                        if let Some(ref mut writer) = log_writer {
-                            let _ =
-                                writeln!(writer, "RX [{}]: {}", get_timestamp(), line.trim_end());
-                            let _ = writer.flush();
+                                if let Some(ref mut writer) = log_writer {
+                                    let _ = writeln!(
+                                        writer,
+                                        "RX [{}]: {}",
+                                        get_timestamp(),
+                                        line.trim_end()
+                                    );
+                                    let _ = writer.flush();
+                                }
+
+                                state.ingest_line(&line, config.plot_points);
+                            }
                         }
-
-                        state.ingest_line(&line, config.plot_points);
-                    }
-                }
-                Ok(_) => {}
-                Err(ref e) if e.kind() == io::ErrorKind::TimedOut => {}
-                Err(e) => {
-                    state.last_error = Some(format!("Read error: {}", e));
+                        Ok(_) => break,
+                        Err(ref e) if e.kind() == io::ErrorKind::TimedOut => break,
+                        Err(e) => {
+                            state.last_error = Some(format!("Read error: {}", e));
+                            break;
+                        }
+                    },
+                    _ => break, // Break the drain loop if the OS buffer is empty
                 }
             }
         }
+
+        // ---Smooth Interpolation (Lerp) ----------
+        let now = Instant::now();
+        let dt = now.duration_since(state.last_frame_time).as_secs_f64();
+        state.last_frame_time = now;
+
+        let target_pitch = state.sensors.get("Pitch").map_or(0.0, |s| s.current_value);
+        let target_yaw = state.sensors.get("Yaw").map_or(0.0, |s| s.current_value);
+        let target_roll = state.sensors.get("Roll").map_or(0.0, |s| s.current_value);
+
+        // Speed multiplier. Higher = faster snapping, Lower = smoother but floaty
+        let lerp_speed = 15.0;
+        let amount = (lerp_speed * dt).clamp(0.0, 1.0);
+
+        // Calculate shortest path for Euler angles to prevent backwards spinning on 360 wrap-around
+        let pitch_diff = (target_pitch - state.display_pitch + 180.0).rem_euclid(360.0) - 180.0;
+        let yaw_diff = (target_yaw - state.display_yaw + 180.0).rem_euclid(360.0) - 180.0;
+        let roll_diff = (target_roll - state.display_roll + 180.0).rem_euclid(360.0) - 180.0;
+
+        state.display_pitch = (state.display_pitch + pitch_diff * amount).rem_euclid(360.0);
+        state.display_yaw = (state.display_yaw + yaw_diff * amount).rem_euclid(360.0);
+        state.display_roll = (state.display_roll + roll_diff * amount).rem_euclid(360.0);
 
         // ── Render ────────────────────────────────────────────────────────────
         let x_bounds = state.x_bounds();
@@ -613,9 +657,9 @@ pub fn run_plotter_mode(
                 }
 
                 ActiveTab::Wireframe3D => {
-                    let pitch_deg = state.sensors.get("Pitch").map_or(0.0, |s| s.current_value);
-                    let yaw_deg = state.sensors.get("Yaw").map_or(0.0, |s| s.current_value);
-                    let roll_deg = state.sensors.get("Roll").map_or(0.0, |s| s.current_value);
+                    let pitch_deg = state.display_pitch;
+                    let yaw_deg = state.display_yaw;
+                    let roll_deg = state.display_roll;
 
                     let mut _rendered_3d = false;
 

--- a/src/plotter.rs
+++ b/src/plotter.rs
@@ -499,7 +499,11 @@ pub fn run_plotter_mode(
                             break;
                         }
                     },
-                    _ => break, // Break the drain loop if the OS buffer is empty
+                    Ok(_) => break, // Break the drain loop if the OS buffer is empty
+                    Err(e) => {
+                        state.last_error = Some(format!("Read error: {}", e));
+                        break;
+                    }
                 }
             }
         }


### PR DESCRIPTION
The telemetry viewer was being very laggy with real IMU data (GY-91). This PR makes it much more smoother.

Closes #81

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes the 3D telemetry viewer smoother and more responsive by adding time-based interpolation and draining the serial buffer each frame with a safe cap. Improves drain-loop error reporting. Closes #81.

- **New Features**
  - Time-based interpolation for pitch, yaw, and roll using `last_frame_time` and a `lerp_speed`.
  - Shortest-path angle blending to handle 360° wrap-around.
  - Wireframe uses interpolated `display_pitch`, `display_yaw`, and `display_roll`.

- **Bug Fixes**
  - Drain OS serial buffer with `bytes_to_read()` in a loop to ingest available data before rendering, reducing lag with fast IMU streams.
  - Clearer read-error messages in the drain loop.
  - Cap drain iterations per frame (10 x 1024B) to avoid blocking the render thread.

<sup>Written for commit bc1f6a22b7cc16289580ae33dba4d637cf6797a8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Vaishnav-Sabari-Girish/ComChan/pull/84?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

