### PR TITLE
feat(rtt): Add `rtt`/`defmt` log viewing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -458,7 +458,7 @@ dependencies = [
 
 [[package]]
 name = "comchan"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "chrono",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,6 +24,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
+name = "alterable_logger"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a1f292171444480aedbc1b7d1a11192d1b6e48f26154cf4635481c58b9b419f"
+dependencies = [
+ "arc-swap",
+ "log",
+ "once_cell",
+]
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -89,6 +100,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "arc-swap"
+version = "1.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a3a1fd6f75306b68087b831f025c712524bcb19aad54e557b1129cfa0a2b207"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
+name = "async-io"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "456b8a8feb6f42d237746d4b3e9a178494627745c3c56c6ea55d92ba50d026fc"
+dependencies = [
+ "autocfg",
+ "cfg-if",
+ "concurrent-queue",
+ "futures-io",
+ "futures-lite",
+ "parking",
+ "polling",
+ "rustix",
+ "slab",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "atomic"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -110,6 +148,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "basic-udev"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a45f9771ced8a774de5e5ebffbe520f52e3943bf5a9a6baa3a5d14a5de1afe6"
+
+[[package]]
+name = "bincode"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36eaf5d7b090263e8150820482d5d93cd964a81e4019913c972f4edcc6edb740"
+dependencies = [
+ "bincode_derive",
+ "serde",
+ "unty",
+]
+
+[[package]]
+name = "bincode_derive"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf95709a440f45e986983918d0e8a1f30a9b1df04918fc828670606804ac3c09"
+dependencies = [
+ "virtue",
+]
+
+[[package]]
 name = "bit-set"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -125,6 +189,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
 
 [[package]]
+name = "bitfield"
+version = "0.19.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21ba6517c6b0f2bf08be60e187ab64b038438f22dd755614d8fe4d4098c46419"
+dependencies = [
+ "bitfield-macros",
+]
+
+[[package]]
+name = "bitfield-macros"
+version = "0.19.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f48d6ace212fdf1b45fd6b566bb40808415344642b76c3224c07c8df9da81e97"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -135,6 +219,21 @@ name = "bitflags"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "bitvec"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
+dependencies = [
+ "funty",
+ "radium",
+ "tap",
+ "wyz",
+]
 
 [[package]]
 name = "block-buffer"
@@ -146,12 +245,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-buffer"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "block2"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
 dependencies = [
  "objc2",
+]
+
+[[package]]
+name = "bs58"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4"
+dependencies = [
+ "tinyvec",
 ]
 
 [[package]]
@@ -165,6 +282,20 @@ name = "bytemuck"
 version = "1.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
+dependencies = [
+ "bytemuck_derive",
+]
+
+[[package]]
+name = "bytemuck_derive"
+version = "1.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9abbd1bc6865053c427f7198e6af43bfdedc55ab791faed4fbd361d789575ff"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "byteorder"
@@ -179,6 +310,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dec551ab6e7578819132c713a93c022a05d60159dc86e7a7050223577484c55a"
 dependencies = [
  "rustversion",
+]
+
+[[package]]
+name = "cbor-edn"
+version = "0.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9b43829b1f353168aa8593c2e4ef6e71a81d6749fe09edfc33849f890c69278"
+dependencies = [
+ "chrono",
+ "data-encoding",
+ "data-encoding-macro",
+ "encoding_rs",
+ "hex",
+ "hexfloat2",
+ "num-bigint",
+ "num-traits",
+ "peg",
 ]
 
 [[package]]
@@ -212,6 +360,7 @@ dependencies = [
  "iana-time-zone",
  "js-sys",
  "num-traits",
+ "serde",
  "wasm-bindgen",
  "windows-link",
 ]
@@ -276,6 +425,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
+name = "cobs"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd93fd2c1b27acd030440c9dbd9d14c1122aad622374fe05a670b67a4bc034be"
+dependencies = [
+ "heapless",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "color_quant"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -288,6 +447,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
+name = "colored"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
+dependencies = [
+ "lazy_static",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "comchan"
 version = "0.8.0"
 dependencies = [
@@ -297,10 +466,13 @@ dependencies = [
  "clap_complete_nushell",
  "crossterm",
  "ctrlc",
+ "defmt-decoder",
  "dirs",
  "inline_colorization",
+ "object 0.39.1",
  "plotters",
  "pretty-hex",
+ "probe-rs",
  "ratatui",
  "ratatui-ratty",
  "ratatui-wireframe",
@@ -323,6 +495,21 @@ dependencies = [
  "ryu",
  "static_assertions",
 ]
+
+[[package]]
+name = "concurrent-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
 
 [[package]]
 name = "convert_case"
@@ -414,6 +601,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
 name = "crossterm"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -451,6 +644,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-common"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "csscolorparser"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -458,6 +660,27 @@ checksum = "eb2a7d3066da2de787b7f032c736763eb7ae5d355f81a68bab2675a96008b0bf"
 dependencies = [
  "lab",
  "phf",
+]
+
+[[package]]
+name = "csv"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52cd9d68cf7efc6ddfaaee42e7288d3a99d613d4b50f76ce9827ae0c6e14f938"
+dependencies = [
+ "csv-core",
+ "itoa",
+ "ryu",
+ "serde_core",
+]
+
+[[package]]
+name = "csv-core"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704a3c26996a80471189265814dbc2c257598b96b8a7feae2d31ace646bb9782"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -473,12 +696,36 @@ dependencies = [
 
 [[package]]
 name = "darling"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
+dependencies = [
+ "darling_core 0.20.11",
+ "darling_macro 0.20.11",
+]
+
+[[package]]
+name = "darling"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
 dependencies = [
- "darling_core",
- "darling_macro",
+ "darling_core 0.23.0",
+ "darling_macro 0.23.0",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -496,11 +743,117 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
+dependencies = [
+ "darling_core 0.20.11",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "darling_macro"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
- "darling_core",
+ "darling_core 0.23.0",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "data-encoding"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
+
+[[package]]
+name = "data-encoding-macro"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3259c913752a86488b501ed8680446a5ed2d5aeac6e596cb23ba3800768ea32c"
+dependencies = [
+ "data-encoding",
+ "data-encoding-macro-internal",
+]
+
+[[package]]
+name = "data-encoding-macro-internal"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccc2776f0c61eca1ca32528f85548abd1a4be8fb53d1b21c013e4f18da1e7090"
+dependencies = [
+ "data-encoding",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "defmt-decoder"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e0427c033f70d46bffe9fc575aa27cb43b1a73d6a0bbe25710c7308809196d2"
+dependencies = [
+ "alterable_logger",
+ "anyhow",
+ "byteorder",
+ "cbor-edn",
+ "colored",
+ "defmt-json-schema",
+ "defmt-parser",
+ "dissimilar",
+ "gimli 0.29.0",
+ "log",
+ "nom",
+ "object 0.36.7",
+ "regex",
+ "ryu",
+ "serde",
+ "serde_json",
+ "time",
+]
+
+[[package]]
+name = "defmt-json-schema"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96b04d228e57a61cf385d86bc8980bb41b47c6fc0eace90592668df97b2dad6a"
+dependencies = [
+ "log",
+ "serde",
+]
+
+[[package]]
+name = "defmt-parser"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10d60334b3b2e7c9d91ef8150abfb6fa4c1c39ebbcf4a81c2e346aad939fee3e"
+dependencies = [
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "deku"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9711031e209dc1306d66985363b4397d4c7b911597580340b93c9729b55f6eb"
+dependencies = [
+ "bitvec",
+ "deku_derive",
+ "no_std_io2",
+ "rustversion",
+]
+
+[[package]]
+name = "deku_derive"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58cb0719583cbe4e81fb40434ace2f0d22ccc3e39a74bb3796c22b451b4f139d"
+dependencies = [
+ "darling 0.20.11",
+ "proc-macro-crate",
+ "proc-macro2",
  "quote",
  "syn 2.0.117",
 ]
@@ -548,8 +901,19 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
- "crypto-common",
+ "block-buffer 0.10.4",
+ "crypto-common 0.1.7",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "block-buffer 0.12.0",
+ "const-oid",
+ "crypto-common 0.2.2",
 ]
 
 [[package]]
@@ -586,12 +950,49 @@ dependencies = [
 ]
 
 [[package]]
+name = "displaydoc"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "dissimilar"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aeda16ab4059c5fd2a83f2b9c9e9c981327b18aa8e3b313f7e6563799d4f093e"
+
+[[package]]
 name = "dlib"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab8ecd87370524b461f8557c119c405552c396ed91fc0a8eec68679eab26f94a"
 dependencies = [
  "libloading",
+]
+
+[[package]]
+name = "docsplay"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8547ea80db62c5bb9d7796fcce5e6e07d1136bdc1a02269095061e806758fab4"
+dependencies = [
+ "docsplay-macros",
+]
+
+[[package]]
+name = "docsplay-macros"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11772ed3eb3db124d826f3abeadf5a791a557f62c19b123e3f07288158a71fdd"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -602,6 +1003,12 @@ checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
 dependencies = [
  "litrs",
 ]
+
+[[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "dwrote"
@@ -622,6 +1029,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 
 [[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -638,6 +1054,48 @@ dependencies = [
 ]
 
 [[package]]
+name = "esp-idf-part"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5ebc2381d030e4e89183554c3fcd4ad44dc5ab34961ab09e09b4adbe4f94b61"
+dependencies = [
+ "bitflags 2.11.1",
+ "csv",
+ "deku",
+ "md-5 0.10.6",
+ "parse_int",
+ "regex",
+ "serde",
+ "serde_plain",
+ "strum 0.27.2",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "espflash"
+version = "4.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d6712ab7c4bd91d8ff9e09bcb1356e25bf19d191177eaac264db8632707236"
+dependencies = [
+ "base64",
+ "bitflags 2.11.1",
+ "bytemuck",
+ "esp-idf-part",
+ "flate2",
+ "gimli 0.32.3",
+ "libc",
+ "log",
+ "md-5 0.11.0",
+ "miette",
+ "nix 0.30.1",
+ "object 0.39.1",
+ "serde",
+ "sha2",
+ "strum 0.28.0",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "euclid"
 version = "0.22.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -645,6 +1103,12 @@ checksum = "f1a05365e3b1c6d1650318537c7460c6923f1abdd272ad6842baa2b509957a06"
 dependencies = [
  "num-traits",
 ]
+
+[[package]]
+name = "fallible-iterator"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
 
 [[package]]
 name = "fancy-regex"
@@ -781,6 +1245,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa9a19cbb55df58761df49b23516a86d432839add4af60fc256da840f66ed35b"
 
 [[package]]
+name = "form_urlencoded"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
+dependencies = [
+ "percent-encoding",
+]
+
+[[package]]
 name = "freetype-sys"
 version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -792,10 +1265,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "funty"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
+
+[[package]]
 name = "futures-core"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-io"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+
+[[package]]
+name = "futures-lite"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f78e10609fe0e0b3f4157ffab1876319b5b0db102a2c60dc4626306dc46b44ad"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+]
 
 [[package]]
 name = "futures-task"
@@ -872,6 +1367,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "gimli"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40ecd4077b5ae9fd2e9e169b102c6c330d0605168eb0e8bf79952b256dbefffd"
+dependencies = [
+ "fallible-iterator",
+ "stable_deref_trait",
+]
+
+[[package]]
+name = "gimli"
+version = "0.32.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
+dependencies = [
+ "fallible-iterator",
+ "indexmap",
+ "stable_deref_trait",
+]
+
+[[package]]
+name = "hash32"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47d60b12902ba28e2730cd37e95b8c9223af2808df9e902d4df49588d1470606"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -898,16 +1423,62 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
+name = "heapless"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ba4bd83f9415b58b4ed8dc5714c76e626a105be4646c02630ad730ad3b5aa4"
+dependencies = [
+ "hash32",
+ "stable_deref_trait",
+]
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hexfloat2"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "befe65164a090041cdf6e0d21a0ec3198d856fbfe2b76e324a073e790bb49f8c"
+
+[[package]]
+name = "hidapi"
+version = "2.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c78dadfc12f865bc3fcac3897e64533b930737ceb9ef245c8277de98d0b010e9"
+dependencies = [
+ "basic-udev",
+ "cc",
+ "cfg-if",
+ "libc",
+ "nix 0.30.1",
+ "pkg-config",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9155a582abd142abc056962c29e3ce5ff2ad5469f4246b537ed42c5deba857da"
+dependencies = [
+ "typenum",
+]
 
 [[package]]
 name = "iana-time-zone"
@@ -934,6 +1505,88 @@ dependencies = [
 ]
 
 [[package]]
+name = "icu_collections"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "utf8_iter",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
+dependencies = [
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
+
+[[package]]
+name = "icu_properties"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
+dependencies = [
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
+
+[[package]]
+name = "icu_provider"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
 name = "id-arena"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -944,6 +1597,33 @@ name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
+name = "idna"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
+]
+
+[[package]]
+name = "ihex"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "365a784774bb381e8c19edb91190a90d7f2625e057b55de2bc0f6b57bc779ff2"
 
 [[package]]
 name = "image"
@@ -992,7 +1672,7 @@ version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5eb2d60ef19920a3a9193c3e371f726ec1dafc045dac788d0fb3704272458971"
 dependencies = [
- "darling",
+ "darling 0.23.0",
  "indoc",
  "proc-macro2",
  "quote",
@@ -1006,7 +1686,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "617ee6cf8e3f66f3b4ea67a4058564628cde41901316e19f559e14c7c72c5e7b"
 dependencies = [
  "core-foundation-sys",
- "mach2",
+ "mach2 0.4.3",
+]
+
+[[package]]
+name = "io-kit-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06d3a048d09fbb6597dbf7c69f40d14df4a49487db1487191618c893fc3b1c26"
+dependencies = [
+ "core-foundation-sys",
+ "mach2 0.5.0",
 ]
 
 [[package]]
@@ -1029,6 +1719,15 @@ name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "jep106"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a1354c92c91fd5595fd4cc46694b6914749cc90ea437246549c26b6ff0ec6d1"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "jpeg-decoder"
@@ -1144,6 +1843,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
+name = "litemap"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
+
+[[package]]
 name = "litrs"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1163,6 +1868,9 @@ name = "log"
 version = "0.4.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "616ec5685824bcc94416c6d4a7a446eea774a31efd7062c8480ba6fd06d7a6e5"
+dependencies = [
+ "serde_core",
+]
 
 [[package]]
 name = "lru"
@@ -1193,6 +1901,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "mach2"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a1b95cd5421ec55b445b5ae102f5ea0e768de1f82bd3001e11f426c269c3aea"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "md-5"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
+dependencies = [
+ "cfg-if",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "md-5"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69b6441f590336821bb897fb28fc622898ccceb1d6cea3fde5ea86b090c4de98"
+dependencies = [
+ "cfg-if",
+ "digest 0.11.3",
+]
+
+[[package]]
 name = "memchr"
 version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1211,6 +1948,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "miette"
+version = "7.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f98efec8807c63c752b5bd61f862c165c115b0a35685bdcfd9238c7aeb592b7"
+dependencies = [
+ "cfg-if",
+ "miette-derive",
+ "unicode-width 0.1.14",
+]
+
+[[package]]
+name = "miette-derive"
+version = "7.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db5b29714e950dbb20d5e6f74f9dcec4edbcc1067bb7f8ed198c097b8c1a818b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1267,6 +2026,18 @@ dependencies = [
 
 [[package]]
 name = "nix"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
+dependencies = [
+ "bitflags 2.11.1",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
+
+[[package]]
+name = "nix"
 version = "0.31.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
@@ -1278,6 +2049,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "no_std_io2"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a3564ce7035b1e4778d8cb6cacebb5d766b5e8fe5a75b9e441e33fb61a872c6"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "nom"
 version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1285,6 +2065,16 @@ checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
 dependencies = [
  "memchr",
  "minimal-lexical",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
 ]
 
 [[package]]
@@ -1302,6 +2092,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -1324,6 +2123,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "nusb"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a330b3bc7f8b4fc729a4c63164b3927eeeaced198222a3ce6b8b6e034851b7a"
+dependencies = [
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "futures-core",
+ "io-kit-sys 0.5.0",
+ "linux-raw-sys",
+ "log",
+ "once_cell",
+ "rustix",
+ "slab",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "objc2"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1337,6 +2154,35 @@ name = "objc2-encode"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
+
+[[package]]
+name = "object"
+version = "0.36.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "object"
+version = "0.38.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "271638cd5fa9cca89c4c304675ca658efc4e64a66c716b7cfe1afb4b9611dbbc"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "object"
+version = "0.39.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e5a6c098c7a3b6547378093f5cc30bc54fd361ce711e05293a5cc589562739b"
+dependencies = [
+ "flate2",
+ "memchr",
+ "ruzstd",
+]
 
 [[package]]
 name = "once_cell"
@@ -1366,6 +2212,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "parking"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
+
+[[package]]
 name = "parking_lot"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1389,6 +2241,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "parse_int"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c464266693329dd5a8715098c7f86e6c5fd5d985018b8318f53d9c6c2b21a31"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "pathfinder_geometry"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1406,6 +2267,39 @@ checksum = "4500030c302e4af1d423f36f3b958d1aecb6c04184356ed5a833bf6b60435777"
 dependencies = [
  "rustc_version",
 ]
+
+[[package]]
+name = "peg"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0aad070be5b63aa72103f2fcdd70a83adbd5e90112ce5b574171ff1c65501773"
+dependencies = [
+ "peg-macros",
+ "peg-runtime",
+]
+
+[[package]]
+name = "peg-macros"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd8ef6825cae95355031ae26a99b616a2a21f22ba2de0197c43dfb05acbe7ee"
+dependencies = [
+ "peg-runtime",
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
+name = "peg-runtime"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7011d97b484a5ebdc4b1fdb3b12d5e4bbbea56e9d22b688f2e79e04b65a7d8a6"
+
+[[package]]
+name = "percent-encoding"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "pest"
@@ -1574,10 +2468,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "polling"
+version = "3.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0e4f59085d47d8241c88ead0f274e8a0cb551f3625263c05eb8dd897c34218"
+dependencies = [
+ "cfg-if",
+ "concurrent-queue",
+ "hermit-abi",
+ "pin-project-lite",
+ "rustix",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "portable-atomic"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+
+[[package]]
+name = "potential_utf"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
+dependencies = [
+ "zerovec",
+]
 
 [[package]]
 name = "powerfmt"
@@ -1599,6 +2516,65 @@ checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "probe-rs"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee50102aaa214117fc4fbe1311077835f0f4faa71e4a769bf65f955cc020ee34"
+dependencies = [
+ "anyhow",
+ "async-io",
+ "bincode",
+ "bitfield",
+ "bitvec",
+ "cobs",
+ "docsplay",
+ "dunce",
+ "espflash",
+ "flate2",
+ "futures-lite",
+ "hidapi",
+ "ihex",
+ "itertools",
+ "jep106",
+ "nusb",
+ "object 0.38.1",
+ "parking_lot",
+ "probe-rs-target",
+ "rmp-serde",
+ "scroll",
+ "serde",
+ "serde_yaml",
+ "serialport",
+ "thiserror 2.0.18",
+ "tracing",
+ "uf2-decode",
+ "zerocopy",
+]
+
+[[package]]
+name = "probe-rs-target"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "031bed1313b45d93dae4ca8f0fee098530c6632e4ebd9e2769d5a49cdef273d3"
+dependencies = [
+ "base64",
+ "indexmap",
+ "jep106",
+ "serde",
+ "serde_with",
+ "url",
+]
+
+[[package]]
+name = "proc-macro-crate"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
+dependencies = [
+ "toml_edit",
 ]
 
 [[package]]
@@ -1630,6 +2606,12 @@ name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "radium"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
@@ -1673,11 +2655,11 @@ dependencies = [
  "itertools",
  "kasuari",
  "lru",
- "strum",
+ "strum 0.27.2",
  "thiserror 2.0.18",
  "unicode-segmentation",
  "unicode-truncate",
- "unicode-width",
+ "unicode-width 0.2.2",
 ]
 
 [[package]]
@@ -1735,10 +2717,10 @@ dependencies = [
  "itertools",
  "line-clipping",
  "ratatui-core",
- "strum",
+ "strum 0.27.2",
  "time",
  "unicode-segmentation",
- "unicode-width",
+ "unicode-width 0.2.2",
 ]
 
 [[package]]
@@ -1801,6 +2783,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
+name = "rmp"
+version = "0.8.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ba8be72d372b2c9b35542551678538b562e7cf86c3315773cae48dfbfe7790c"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "rmp-serde"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72f81bee8c8ef9b577d1681a70ebbc962c232461e397b22c208c43c04b67a155"
+dependencies = [
+ "rmp",
+ "serde",
+]
+
+[[package]]
 name = "rustc_version"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1829,6 +2830,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
+name = "ruzstd"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7c1c839d570d835527c9a5e4db7cb2198683a988cb9d7293fc8674e6bd58fc8"
+dependencies = [
+ "twox-hash",
+]
+
+[[package]]
 name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1848,6 +2858,12 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "scroll"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1257cd4248b4132760d6524d6dda4e053bc648c9070b960929bf50cfb1e7add"
 
 [[package]]
 name = "semver"
@@ -1899,12 +2915,50 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_plain"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ce1fc6db65a611022b23a0dec6975d63fb80a302cb3388835ff02c097258d50"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde_spanned"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
 dependencies = [
  "serde_core",
+]
+
+[[package]]
+name = "serde_with"
+version = "3.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76a5c54c7310e7b8b9577c286d7e399ddd876c3e12b3ed917a8aabc4b96e9e8c"
+dependencies = [
+ "base64",
+ "bs58",
+ "chrono",
+ "hex",
+ "indexmap",
+ "serde_core",
+ "serde_json",
+ "time",
+]
+
+[[package]]
+name = "serde_yaml"
+version = "0.9.34+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+dependencies = [
+ "indexmap",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
 ]
 
 [[package]]
@@ -1917,9 +2971,9 @@ dependencies = [
  "cfg-if",
  "core-foundation 0.10.1",
  "core-foundation-sys",
- "io-kit-sys",
+ "io-kit-sys 0.4.1",
  "libudev",
- "mach2",
+ "mach2 0.4.3",
  "nix 0.26.4",
  "scopeguard",
  "unescaper",
@@ -1934,7 +2988,7 @@ checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
  "cpufeatures",
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -2005,6 +3059,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1527984ca054dfca79333baec451042863f485fbee01b7bf6d911de915cac865"
 
 [[package]]
+name = "stable_deref_trait"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
 name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2022,7 +3082,16 @@ version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
 dependencies = [
- "strum_macros",
+ "strum_macros 0.27.2",
+]
+
+[[package]]
+name = "strum"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9628de9b8791db39ceda2b119bbe13134770b56c138ec1d3af810d045c04f9bd"
+dependencies = [
+ "strum_macros 0.28.0",
 ]
 
 [[package]]
@@ -2030,6 +3099,18 @@ name = "strum_macros"
 version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab85eea0270ee17587ed4156089e10b9e6880ee688791d45a905f5b1ca36f664"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -2058,6 +3139,23 @@ dependencies = [
  "quote",
  "unicode-ident",
 ]
+
+[[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "tap"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "terminfo"
@@ -2169,12 +3267,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
 dependencies = [
  "deranged",
+ "itoa",
  "libc",
  "num-conv",
  "num_threads",
  "powerfmt",
  "serde_core",
  "time-core",
+ "time-macros",
 ]
 
 [[package]]
@@ -2182,6 +3282,41 @@ name = "time-core"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+
+[[package]]
+name = "time-macros"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+dependencies = [
+ "num-conv",
+ "time-core",
+]
+
+[[package]]
+name = "tinystr"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
+dependencies = [
+ "displaydoc",
+ "zerovec",
+]
+
+[[package]]
+name = "tinyvec"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "toml"
@@ -2208,6 +3343,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml_edit"
+version = "0.25.12+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2153edc6955a6c354fad8f5efd38b6a8769bdccf9fe50f8e1329f81b0baa5d7"
+dependencies = [
+ "indexmap",
+ "toml_datetime",
+ "toml_parser",
+ "winnow",
+]
+
+[[package]]
 name = "toml_parser"
 version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2223,10 +3370,47 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
+name = "tracing"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
+dependencies = [
+ "pin-project-lite",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
 name = "ttf-parser"
 version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17f77d76d837a7830fe1d4f12b7b4ba4192c1888001c7164257e4bc6d21d96b4"
+
+[[package]]
+name = "twox-hash"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ea3136b675547379c4bd395ca6b938e5ad3c3d20fad76e7fe85f9e0d011419c"
 
 [[package]]
 name = "typenum"
@@ -2239,6 +3423,12 @@ name = "ucd-trie"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
+
+[[package]]
+name = "uf2-decode"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca77d41ab27e3fa45df42043f96c79b80c6d8632eed906b54681d8d47ab00623"
 
 [[package]]
 name = "unescaper"
@@ -2269,8 +3459,14 @@ checksum = "16b380a1238663e5f8a691f9039c73e1cdae598a30e9855f541d29b08b53e9a5"
 dependencies = [
  "itertools",
  "unicode-segmentation",
- "unicode-width",
+ "unicode-width 0.2.2",
 ]
+
+[[package]]
+name = "unicode-width"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
 name = "unicode-width"
@@ -2283,6 +3479,37 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
+
+[[package]]
+name = "unty"
+version = "0.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d49784317cd0d1ee7ec5c716dd598ec5b4483ea832a2dced265471cc0f690ae"
+
+[[package]]
+name = "url"
+version = "2.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+ "serde",
+ "serde_derive",
+]
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "utf8parse"
@@ -2307,6 +3534,12 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "virtue"
+version = "0.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "051eb1abcf10076295e815102942cc58f9d5e3b4560e46e53c21e8ff6f3af7b1"
 
 [[package]]
 name = "vtparse"
@@ -2695,6 +3928,9 @@ name = "winnow"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "wio"
@@ -2806,6 +4042,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8d67316c98c974f25c91ef05c9110edad3543f034572a688de7d67c2c746bdf"
 
 [[package]]
+name = "writeable"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+
+[[package]]
+name = "wyz"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
+dependencies = [
+ "tap",
+]
+
+[[package]]
 name = "yeslogic-fontconfig-sys"
 version = "6.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2814,6 +4065,103 @@ dependencies = [
  "dlib",
  "once_cell",
  "pkg-config",
+]
+
+[[package]]
+name = "yoke"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5"
+dependencies = [
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "synstructure",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.52"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce1022995ff5ff5d841ad7d994facc23098cd40152f2c1d11cd607c6f530653f"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.52"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "zerofrom"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "synstructure",
+]
+
+[[package]]
+name = "zerotrie"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "comchan"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2024"
 authors = ["Vaishnav Sabari Girish <vaishnav.sabari.girish@gmail.com>"]
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,10 +22,13 @@ clap_complete = "4.6.3"
 clap_complete_nushell = "4.6.0"
 crossterm = "0.29.0"
 ctrlc = "3.5"
+defmt-decoder = "1.1.0"
 dirs = "6.0.0"
 inline_colorization = "0.1.6"
+object = "0.39.1"
 plotters = "0.3.7"
 pretty-hex = "0.4.2"
+probe-rs = "0.31.0"
 ratatui = "0.30.0"
 ratatui-ratty = { version = "0.3.0", optional = true }
 ratatui-wireframe = { version = "0.6.0", path = "crates/ratatui-wireframe" }

--- a/src/config.rs
+++ b/src/config.rs
@@ -237,6 +237,15 @@ pub struct Args {
 
     #[arg(long, default_value_t = false, help = "Exports the plot in Dark Mode")]
     pub dark: bool,
+
+    #[arg(long, default_value_t = false, help = "View RTT logs")]
+    pub rtt: bool,
+
+    #[arg(long, requires = "rtt", help = "The Path to the compiled .elf file")]
+    pub elf: Option<String>,
+
+    #[arg(long, requires = "rtt", help = "Chip name for probe-rs")]
+    pub chip: Option<String>,
 }
 
 /// The resolved, merged configuration used at runtime.
@@ -265,6 +274,9 @@ pub struct MergedConfig {
     pub obj_file: Option<String>,
     pub braille: BrailleModel,
     pub dark_mode: bool,
+    pub rtt: bool,
+    pub elf: Option<String>,
+    pub chip: Option<String>,
 }
 
 // Generate completions
@@ -456,5 +468,8 @@ pub fn merge_config_and_args(config: Config, args: Args) -> MergedConfig {
             .or(config.braille)
             .unwrap_or(BrailleModel::Cube),
         dark_mode: args.dark,
+        rtt: args.rtt,
+        elf: args.elf,
+        chip: args.chip,
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -238,7 +238,13 @@ pub struct Args {
     #[arg(long, default_value_t = false, help = "Exports the plot in Dark Mode")]
     pub dark: bool,
 
-    #[arg(long, default_value_t = false, help = "View RTT logs")]
+    #[arg(
+        long,
+        default_value_t = false,
+        requires = "elf",
+        requires = "chip",
+        help = "View RTT logs"
+    )]
     pub rtt: bool,
 
     #[arg(long, requires = "rtt", help = "The Path to the compiled .elf file")]

--- a/src/config.rs
+++ b/src/config.rs
@@ -242,7 +242,6 @@ pub struct Args {
         long,
         default_value_t = false,
         requires = "elf",
-        requires = "chip",
         help = "View RTT logs"
     )]
     pub rtt: bool,

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,6 +8,7 @@ mod parser;
 mod plotter;
 mod port_finder;
 mod replay;
+mod rtt_reader;
 mod serial;
 
 use config::{
@@ -61,9 +62,14 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         return list_available_ports();
     }
 
-    let port_name = if merged.simulate || merged.replay_file.is_some() {
-        println!("{color_magenta}Starting in SIMULATE/REPLAY mode....{color_reset}");
-        "SIMULATE_PORT".to_string()
+    let port_name = if merged.simulate || merged.replay_file.is_some() || merged.rtt {
+        if merged.rtt {
+            println!("{color_magenta}Starting in RTT/DEFMT debug probe mode....{color_reset}");
+            "RTT_DEBUG_PROBE".to_string()
+        } else {
+            println!("{color_magenta}Starting in SIMULATE/REPLAY mode....{color_reset}");
+            "SIMULATE_PORT".to_string()
+        }
     } else {
         match &merged.port {
             Some(p) if p.to_lowercase() == "auto" => match port_finder::find_usb_port()? {

--- a/src/monitor.rs
+++ b/src/monitor.rs
@@ -49,14 +49,17 @@ pub fn run_normal_mode(
     config: MergedConfig,
     port_name: String,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let data_bits =
-        parse_data_bits(config.data_bits).map_err(|e| format!("Configuration error: {}", e))?;
-    let stop_bits =
-        parse_stop_bits(config.stop_bits).map_err(|e| format!("Configuration error: {}", e))?;
-    let parity = parse_parity(&config.parity).map_err(|e| format!("Configuration error: {}", e))?;
-    let flow_control = parse_flow_control(&config.flow_control)
-        .map_err(|e| format!("Configuration error: {}", e))?;
-
+    let serial_config = if config.simulate || config.replay_file.is_some() || config.rtt {
+        None
+    } else {
+        Some((
+            parse_data_bits(config.data_bits).map_err(|e| format!("Configuration error: {}", e))?,
+            parse_stop_bits(config.stop_bits).map_err(|e| format!("Configuration error: {}", e))?,
+            parse_parity(&config.parity).map_err(|e| format!("Configuration error: {}", e))?,
+            parse_flow_control(&config.flow_control)
+                .map_err(|e| format!("Configuration error: {}", e))?,
+        ))
+    };
     // 1. Setup logging ONCE
     let mut log_writer = if let Some(log_path) = &config.log_file {
         let file = OpenOptions::new()
@@ -155,7 +158,17 @@ pub fn run_normal_mode(
                 return Err("RTT mode requires an ELF file. Use --elf <path>".into());
             }
 
-            Some(RttDefmtReader::new(elf, config.chip.clone())?)
+            match RttDefmtReader::new(elf, config.chip.clone()) {
+                Ok(reader) => Some(reader),
+                Err(e) => {
+                    eprintln!(
+                        "\r\n{color_yellow}⏳ Waiting for RTT target ({color_red}{}{color_yellow})...{color_reset}",
+                        e
+                    );
+                    thread::sleep(Duration::from_millis(1000));
+                    continue;
+                }
+            }
         } else {
             None
         };
@@ -165,6 +178,7 @@ pub fn run_normal_mode(
             None
         } else {
             // Match handles the error instead of returning it
+            let (data_bits, stop_bits, parity, flow_control) = serial_config.unwrap();
             match serialport::new(&port_name, config.baud)
                 .timeout(Duration::from_millis(config.timeout_ms))
                 .data_bits(data_bits)

--- a/src/monitor.rs
+++ b/src/monitor.rs
@@ -86,18 +86,6 @@ pub fn run_normal_mode(
         None
     };
 
-    // Initialize RTT reader
-    let mut rtt_reader = if config.rtt {
-        let elf = config.elf.as_deref().unwrap_or("");
-        if elf.is_empty() {
-            return Err("RTT mode requires an ELF file. Use --elf <path>".into());
-        }
-
-        Some(RttDefmtReader::new(elf, config.chip.clone())?)
-    } else {
-        None
-    };
-
     println!("{color_green} Listening… (Ctrl+C to exit, Ctrl+L to clear screen){color_reset}\n");
 
     // 2. Setup channels and input thread ONCE
@@ -160,6 +148,19 @@ pub fn run_normal_mode(
 
     // Connection & Reconnection
     while running.load(std::sync::atomic::Ordering::SeqCst) {
+        // Initialize RTT reader
+        let mut rtt_reader = if config.rtt {
+            let elf = config.elf.as_deref().unwrap_or("");
+            if elf.is_empty() {
+                return Err("RTT mode requires an ELF file. Use --elf <path>".into());
+            }
+
+            Some(RttDefmtReader::new(elf, config.chip.clone())?)
+        } else {
+            None
+        };
+
+        // Serial Port
         let mut port = if config.simulate || config.replay_file.is_some() || config.rtt {
             None
         } else {
@@ -264,34 +265,55 @@ pub fn run_normal_mode(
                     }
                 }
             } else if let Some(reader) = rtt_reader.as_mut() {
-                if let Ok(logs) = reader.poll_logs() {
-                    if logs.is_empty() {
-                        thread::sleep(Duration::from_millis(10));
-                    } else {
-                        for line in logs {
-                            let trimmed = line.trim_end();
+                match reader.poll_logs() {
+                    Ok(logs) => {
+                        if logs.is_empty() {
+                            thread::sleep(Duration::from_millis(10));
+                        } else {
+                            for line in logs {
+                                let trimmed = line.trim_end();
 
-                            if trimmed.is_empty() {
-                                continue;
-                            }
+                                if trimmed.is_empty() {
+                                    continue;
+                                }
 
-                            if config.verbose {
-                                print!("\r[{}] {}\r\n", get_timestamp(), trimmed);
-                            } else {
-                                print!("\r{}\r\n", trimmed);
-                            }
-                            io::stdout().flush().ok();
+                                if config.verbose {
+                                    print!("\r[{}] {}\r\n", get_timestamp(), trimmed);
+                                } else {
+                                    print!("\r{}\r\n", trimmed);
+                                }
+                                io::stdout().flush().ok();
 
-                            if let Some(ref mut writer) = log_writer {
-                                writeln!(writer, "RX [{}]: {}", get_timestamp(), trimmed).ok();
-                                let _ = writer.flush();
-                            }
+                                if let Some(ref mut writer) = log_writer {
+                                    writeln!(writer, "RX [{}]: {}", get_timestamp(), trimmed).ok();
+                                    let _ = writer.flush();
+                                }
 
-                            if let Some(ref mut streamer) = csv_streamer {
-                                let readings = crate::parser::parse_sensor_data(trimmed);
-                                let _ = streamer.write_row(&readings);
+                                if let Some(ref mut streamer) = csv_streamer {
+                                    let readings = crate::parser::parse_sensor_data(trimmed);
+                                    let _ = streamer.write_row(&readings);
+                                }
                             }
                         }
+                    }
+
+                    Err(e) => {
+                        eprintln!(
+                            "\r\n{color_yellow}⚠️ RTT connection lost ({color_red}{}{color_yellow}). Attempting to reconnect...{color_reset}",
+                            e
+                        );
+
+                        if let Some(ref mut writer) = log_writer {
+                            writeln!(
+                                writer,
+                                "ERROR [{}]: RTT connection lost: {}",
+                                get_timestamp(),
+                                e
+                            )
+                            .ok();
+                            let _ = writer.flush();
+                        }
+                        is_connected = false;
                     }
                 }
             } else if let Some(p) = port.as_mut() {
@@ -481,6 +503,7 @@ pub fn run_normal_mode(
                         eprintln!(
                             "\r\n{color_yellow}Sending Input over RTT is not supported{color_reset}"
                         );
+                        continue;
                     }
 
                     last_sent = Some(clean.to_string());

--- a/src/monitor.rs
+++ b/src/monitor.rs
@@ -154,17 +154,22 @@ pub fn run_normal_mode(
         // Initialize RTT reader
         let mut rtt_reader = if config.rtt {
             let elf = config.elf.as_deref().unwrap_or("");
-            if elf.is_empty() {
-                return Err("RTT mode requires an ELF file. Use --elf <path>".into());
-            }
 
             match RttDefmtReader::new(elf, config.chip.clone()) {
                 Ok(reader) => Some(reader),
                 Err(e) => {
-                    eprintln!(
-                        "\r\n{color_yellow}⏳ Waiting for RTT target ({color_red}{}{color_yellow})...{color_reset}",
-                        e
-                    );
+                    let err_msg = e.to_string();
+
+                    if err_msg.contains("No such file")
+                        || err_msg.contains("No defmt table")
+                        || err_msg.contains("ChipNotFound")
+                        || err_msg.contains("requires an ELF file")
+                    {
+                        return Err(e);
+                    }
+                    // Otherwise, treat as a transient hardware/connection error and wait
+                    print!("\r{color_yellow}⏳ Waiting for RTT target...{color_reset}\x1b[K");
+                    io::stdout().flush().ok();
                     thread::sleep(Duration::from_millis(1000));
                     continue;
                 }

--- a/src/monitor.rs
+++ b/src/monitor.rs
@@ -1,4 +1,5 @@
 use crate::config::MergedConfig;
+use crate::rtt_reader::RttDefmtReader;
 use crate::serial::{
     get_timestamp, parse_data_bits, parse_flow_control, parse_parity, parse_stop_bits,
 };
@@ -85,6 +86,18 @@ pub fn run_normal_mode(
         None
     };
 
+    // Initialize RTT reader
+    let mut rtt_reader = if config.rtt {
+        let elf = config.elf.as_deref().unwrap_or("");
+        if elf.is_empty() {
+            return Err("RTT mode requires an ELF file. Use --elf <path>".into());
+        }
+
+        Some(RttDefmtReader::new(elf, config.chip.clone())?)
+    } else {
+        None
+    };
+
     println!("{color_green} Listening… (Ctrl+C to exit, Ctrl+L to clear screen){color_reset}\n");
 
     // 2. Setup channels and input thread ONCE
@@ -147,7 +160,7 @@ pub fn run_normal_mode(
 
     // Connection & Reconnection
     while running.load(std::sync::atomic::Ordering::SeqCst) {
-        let mut port = if config.simulate || config.replay_file.is_some() {
+        let mut port = if config.simulate || config.replay_file.is_some() || config.rtt {
             None
         } else {
             // Match handles the error instead of returning it
@@ -248,6 +261,37 @@ pub fn run_normal_mode(
                         println!("\n{color_yellow}Replay Finished.{color_reset}");
                         running.store(false, std::sync::atomic::Ordering::SeqCst);
                         break;
+                    }
+                }
+            } else if let Some(reader) = rtt_reader.as_mut() {
+                if let Ok(logs) = reader.poll_logs() {
+                    if logs.is_empty() {
+                        thread::sleep(Duration::from_millis(10));
+                    } else {
+                        for line in logs {
+                            let trimmed = line.trim_end();
+
+                            if trimmed.is_empty() {
+                                continue;
+                            }
+
+                            if config.verbose {
+                                print!("\r[{}] {}\r\n", get_timestamp(), trimmed);
+                            } else {
+                                print!("\r{}\r\n", trimmed);
+                            }
+                            io::stdout().flush().ok();
+
+                            if let Some(ref mut writer) = log_writer {
+                                writeln!(writer, "RX [{}]: {}", get_timestamp(), trimmed).ok();
+                                let _ = writer.flush();
+                            }
+
+                            if let Some(ref mut streamer) = csv_streamer {
+                                let readings = crate::parser::parse_sensor_data(trimmed);
+                                let _ = streamer.write_row(&readings);
+                            }
+                        }
                     }
                 }
             } else if let Some(p) = port.as_mut() {
@@ -433,6 +477,10 @@ pub fn run_normal_mode(
                             continue;
                         }
                         p.flush().ok();
+                    } else if config.rtt {
+                        eprintln!(
+                            "\r\n{color_yellow}Sending Input over RTT is not supported{color_reset}"
+                        );
                     }
 
                     last_sent = Some(clean.to_string());

--- a/src/plotter.rs
+++ b/src/plotter.rs
@@ -497,9 +497,16 @@ pub fn run_plotter_mode(
                     state.last_error = Some(format!("RTT lost: {}. Reconnecting...", e));
 
                     let elf = config.elf.as_deref().unwrap_or("");
-                    if let Ok(new_reader) = RttDefmtReader::new(elf, config.chip.clone()) {
-                        *reader = new_reader;
-                        state.last_error = Some("RTT re-connected!".to_string());
+                    match RttDefmtReader::new(elf, config.chip.clone()) {
+                        Ok(new_reader) => {
+                            *reader = new_reader;
+                            state.last_error = Some("RTT re-connected!".to_string());
+                        }
+                        Err(err) => {
+                            state.last_error = Some(format!("RTT re-connect failed: {}", err));
+
+                            std::thread::sleep(Duration::from_millis(500));
+                        }
                     }
                 }
             }

--- a/src/plotter.rs
+++ b/src/plotter.rs
@@ -482,13 +482,25 @@ pub fn run_plotter_mode(
             }
         } else if let Some(reader) = rtt_reader.as_mut() {
             // Drain RTT/DEFMT buffer
-            if let Ok(logs) = reader.poll_logs() {
-                for line in logs {
-                    if let Some(ref mut writer) = log_writer {
-                        let _ = writeln!(writer, "RX [{}]: {}", get_timestamp(), line.trim_end());
-                        let _ = writer.flush();
+            match reader.poll_logs() {
+                Ok(logs) => {
+                    for line in logs {
+                        if let Some(ref mut writer) = log_writer {
+                            let _ =
+                                writeln!(writer, "RX [{}]: {}", get_timestamp(), line.trim_end());
+                            let _ = writer.flush();
+                        }
+                        state.ingest_line(&line, config.plot_points);
                     }
-                    state.ingest_line(&line, config.plot_points);
+                }
+                Err(e) => {
+                    state.last_error = Some(format!("RTT lost: {}. Reconnecting...", e));
+
+                    let elf = config.elf.as_deref().unwrap_or("");
+                    if let Ok(new_reader) = RttDefmtReader::new(elf, config.chip.clone()) {
+                        *reader = new_reader;
+                        state.last_error = Some("RTT re-connected!".to_string());
+                    }
                 }
             }
         } else if let Some(p) = port.as_mut() {

--- a/src/plotter.rs
+++ b/src/plotter.rs
@@ -1,5 +1,6 @@
 use crate::config::MergedConfig;
 use crate::parser::{SensorData, get_color_for_index, parse_sensor_data};
+use crate::rtt_reader::RttDefmtReader;
 use crate::serial::{
     get_timestamp, parse_data_bits, parse_flow_control, parse_parity, parse_stop_bits,
 };
@@ -321,6 +322,17 @@ pub fn run_plotter_mode(
     let parity = parse_parity(&config.parity)?;
     let flow_control = parse_flow_control(&config.flow_control)?;
 
+    let mut rtt_reader = if config.rtt {
+        let elf = config.elf.as_deref().unwrap_or("");
+
+        if elf.is_empty() {
+            return Err("RTT mode requires an ELF file. Use --elf <path>".into());
+        }
+        Some(RttDefmtReader::new(elf, config.chip.clone())?)
+    } else {
+        None
+    };
+
     let mut port = if config.simulate || config.replay_file.is_some() {
         None
     } else {
@@ -466,6 +478,17 @@ pub fn run_plotter_mode(
                 crate::replay::ReplayEvent::Waiting => {}
                 crate::replay::ReplayEvent::Eof => {
                     std::thread::sleep(Duration::from_millis(100));
+                }
+            }
+        } else if let Some(reader) = rtt_reader.as_mut() {
+            // Drain RTT/DEFMT buffer
+            if let Ok(logs) = reader.poll_logs() {
+                for line in logs {
+                    if let Some(ref mut writer) = log_writer {
+                        let _ = writeln!(writer, "RX [{}]: {}", get_timestamp(), line.trim_end());
+                        let _ = writer.flush();
+                    }
+                    state.ingest_line(&line, config.plot_points);
                 }
             }
         } else if let Some(p) = port.as_mut() {

--- a/src/plotter.rs
+++ b/src/plotter.rs
@@ -311,12 +311,6 @@ pub fn run_plotter_mode(
     config: MergedConfig,
     port_name: String,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    enable_raw_mode()?;
-    let mut stdout = io::stdout();
-    execute!(stdout, EnterAlternateScreen)?;
-    let backend = CrosstermBackend::new(stdout);
-    let mut terminal = Terminal::new(backend)?;
-
     let data_bits = parse_data_bits(config.data_bits)?;
     let stop_bits = parse_stop_bits(config.stop_bits)?;
     let parity = parse_parity(&config.parity)?;
@@ -333,7 +327,7 @@ pub fn run_plotter_mode(
         None
     };
 
-    let mut port = if config.simulate || config.replay_file.is_some() {
+    let mut port = if config.simulate || config.replay_file.is_some() || config.rtt {
         None
     } else {
         Some(
@@ -346,6 +340,13 @@ pub fn run_plotter_mode(
                 .open()?,
         )
     };
+
+    enable_raw_mode()?;
+    let mut stdout = io::stdout();
+    execute!(stdout, EnterAlternateScreen)?;
+    let backend = CrosstermBackend::new(stdout);
+    let mut terminal = Terminal::new(backend)?;
+
     let mut log_writer: Option<BufWriter<std::fs::File>> =
         if let Some(ref log_path) = config.log_file {
             let file = OpenOptions::new()

--- a/src/plotter.rs
+++ b/src/plotter.rs
@@ -311,25 +311,14 @@ pub fn run_plotter_mode(
     config: MergedConfig,
     port_name: String,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let data_bits = parse_data_bits(config.data_bits)?;
-    let stop_bits = parse_stop_bits(config.stop_bits)?;
-    let parity = parse_parity(&config.parity)?;
-    let flow_control = parse_flow_control(&config.flow_control)?;
-
-    let mut rtt_reader = if config.rtt {
-        let elf = config.elf.as_deref().unwrap_or("");
-
-        if elf.is_empty() {
-            return Err("RTT mode requires an ELF file. Use --elf <path>".into());
-        }
-        Some(RttDefmtReader::new(elf, config.chip.clone())?)
-    } else {
-        None
-    };
-
     let mut port = if config.simulate || config.replay_file.is_some() || config.rtt {
         None
     } else {
+        let data_bits = parse_data_bits(config.data_bits)?;
+        let stop_bits = parse_stop_bits(config.stop_bits)?;
+        let parity = parse_parity(&config.parity)?;
+        let flow_control = parse_flow_control(&config.flow_control)?;
+
         Some(
             serialport::new(&port_name, config.baud)
                 .timeout(Duration::from_millis(config.timeout_ms))
@@ -339,6 +328,16 @@ pub fn run_plotter_mode(
                 .flow_control(flow_control)
                 .open()?,
         )
+    };
+    let mut rtt_reader = if config.rtt {
+        let elf = config.elf.as_deref().unwrap_or("");
+
+        if elf.is_empty() {
+            return Err("RTT mode requires an ELF file. Use --elf <path>".into());
+        }
+        Some(RttDefmtReader::new(elf, config.chip.clone())?)
+    } else {
+        None
     };
 
     enable_raw_mode()?;

--- a/src/rtt_reader.rs
+++ b/src/rtt_reader.rs
@@ -1,0 +1,147 @@
+use defmt_decoder::{DecodeError, StreamDecoder, Table};
+use object::{Object, ObjectSymbol};
+use probe_rs::{
+    Permissions, Session,
+    config::TargetSelector,
+    probe::list::Lister,
+    rtt::{Rtt, ScanRegion},
+};
+use std::fs;
+
+pub struct RttDefmtReader {
+    session: Session,
+    rtt: Rtt,
+    stream_decoder: Box<dyn StreamDecoder>,
+}
+
+impl RttDefmtReader {
+    pub fn new(
+        elf_path: &str,
+        chip_override: Option<String>,
+    ) -> Result<Self, Box<dyn std::error::Error>> {
+        let elf_bytes = fs::read(elf_path)?;
+        let elf_bytes_ref: &'static [u8] = Box::leak(elf_bytes.into_boxed_slice());
+
+        let table = Table::parse(elf_bytes_ref)?
+            .ok_or("No defmt table found. Is the firmware compiled with defmt?")?;
+
+        let table_ref: &'static Table = Box::leak(Box::new(table));
+        let stream_decoder = table_ref.new_stream_decoder();
+
+        // ── INSTANT ATTACH FIX ──
+        // Instead of scanning all of RAM, we parse the ELF file to find the exact
+        // memory address of the RTT control block. This reduces attach time from 3s to 0.01s.
+        let rtt_addr = {
+            let obj_file = object::File::parse(elf_bytes_ref)?;
+            obj_file
+                .symbols()
+                .find(|sym| sym.name() == Ok("_SEGGER_RTT"))
+                .map(|sym| sym.address() as u32)
+        };
+
+        let lister = Lister::new();
+        let probes = lister.list_all();
+
+        if probes.is_empty() {
+            return Err("No debug probes detected. Check your USB connection.".into());
+        }
+
+        let probe = probes[0].open()?;
+
+        let target_selector = match chip_override {
+            Some(chip) => TargetSelector::Unspecified(chip),
+            None => TargetSelector::Auto,
+        };
+
+        let mut session = probe.attach(target_selector, Permissions::default()).map_err(|e| {
+            format!(
+                "Failed to attach: {}\nHint: Try specifying the chip manually using --chip (e.g., --chip nRF52840_xxAA)",
+                e
+            )
+        })?;
+
+        let rtt = {
+            let mut core = session.core(0)?;
+
+            if let Some(addr) = rtt_addr {
+                // Fast path: We know exactly where it is!
+                Rtt::attach_region(&mut core, &ScanRegion::Exact(addr as u64))?
+            } else {
+                // Slow path fallback: Scan RAM, taking the highest address to avoid Flash mirrors
+                match Rtt::attach_region(&mut core, &ScanRegion::Ram) {
+                    Ok(rtt) => rtt,
+                    Err(probe_rs::rtt::Error::MultipleControlBlocksFound(addrs)) => {
+                        let active_addr = addrs.into_iter().max().expect("Address list empty");
+                        Rtt::attach_region(&mut core, &ScanRegion::Exact(active_addr))?
+                    }
+                    Err(e) => return Err(e.into()),
+                }
+            }
+        };
+
+        Ok(Self {
+            session,
+            rtt,
+            stream_decoder,
+        })
+    }
+
+    pub fn poll_logs(&mut self) -> Result<Vec<String>, Box<dyn std::error::Error>> {
+        let mut logs = Vec::new();
+        let mut core = self.session.core(0)?;
+
+        if let Some(channel) = self.rtt.up_channels().first_mut() {
+            let mut buf = [0u8; 1024];
+            let bytes_read = channel.read(&mut core, &mut buf)?;
+
+            if bytes_read > 0 {
+                self.stream_decoder.received(&buf[..bytes_read]);
+
+                loop {
+                    match self.stream_decoder.decode() {
+                        Ok(frame) => {
+                            let timestamp = frame
+                                .display_timestamp()
+                                .map(|t| t.to_string())
+                                .unwrap_or_default();
+
+                            let raw_level = frame
+                                .level()
+                                .map(|l| l.as_str().to_uppercase())
+                                .unwrap_or_else(|| "UNK".to_string());
+                            let padded_level = format!("{:5}", raw_level);
+
+                            // Apply standard terminal ANSI color codes
+                            let colored_level = match raw_level.as_str() {
+                                "ERROR" => format!("\x1b[31;1m{}\x1b[0m", padded_level), // Bold Red
+                                "WARN" => format!("\x1b[33;1m{}\x1b[0m", padded_level), // Bold Yellow
+                                "INFO" => format!("\x1b[32m{}\x1b[0m", padded_level),   // Green
+                                "DEBUG" => format!("\x1b[36m{}\x1b[0m", padded_level),  // Cyan
+                                "TRACE" => format!("\x1b[90m{}\x1b[0m", padded_level),  // Gray/Dim
+                                _ => padded_level,
+                            };
+
+                            let message = frame.display_message().to_string();
+
+                            let formatted = if timestamp.is_empty() {
+                                format!("[{}] {}", colored_level, message)
+                            } else {
+                                format!("{} [{}] {}", timestamp, colored_level, message)
+                            };
+
+                            logs.push(formatted);
+                        }
+                        // SILENTLY handle partial frames. Do not print "Unexpected EOF" here!
+                        Err(DecodeError::UnexpectedEof) => break,
+                        Err(DecodeError::Malformed) => {
+                            eprintln!("Warning: Malformed defmt frame detected.");
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+
+        Ok(logs)
+    }
+}

--- a/src/rtt_reader.rs
+++ b/src/rtt_reader.rs
@@ -46,6 +46,14 @@ impl RttDefmtReader {
             return Err("No debug probes detected. Check your USB connection.".into());
         }
 
+        if probes.len() > 1 {
+            eprintln!("⚠️ Warning: Multiple debug probes detected!");
+            eprintln!(
+                "⚠️ Silently attaching to the first enumerated probe: {}",
+                probes[0].identifier
+            );
+        }
+
         let probe = probes[0].open()?;
 
         let target_selector = match chip_override {


### PR DESCRIPTION
Users can now view `rtt`/`defmt` logs by passing the `--rtt` flag. But
this flag also requires the `--elf` (Path to the ELF file) and the `--chip` (Chip name) flag for it to work.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add RTT/defmt log viewing via the new --rtt flag so you can read firmware logs over a debug probe without a serial port. Integrates with monitor/plotter, prints color-coded levels with timestamps, and now surfaces config and reconnect errors clearly while reliably auto-reconnecting after resets.

- **New Features**
  - Flags: --rtt (enable), --elf <path> (required), --chip <name> (optional; auto-detect by default).
  - Monitor and plotter read RTT, decode `defmt`, stream to log/CSV; plotter ingests values from RTT lines.
  - Input sending is disabled in RTT mode (warns if attempted). No serial port needed; --port is ignored.
  - Fast attach using the `_SEGGER_RTT` symbol when present; falls back to RAM scan and picks the highest control block.

- **Bug Fixes**
  - Reconnect is now reliable after target resets by creating the RTT reader inside the reconnect loop.
  - Fixed connection state so reconnect triggers on RTT/USB drop.
  - In RTT mode, serial config parsing is deferred to avoid crashing on unrelated serial settings.
  - Improved error handling: missing ELF, no defmt table, or unknown chip now fail fast; transient probe/target issues show a “Waiting for RTT target…” status and auto-retry; reconnect failures now propagate to the UI/logs (plotter/monitor) and back off before retrying.

<sup>Written for commit 90a8b324044ed5ba936a41f4a84aabf032073ccd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Vaishnav-Sabari-Girish/ComChan/pull/87?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

