### PR TITLE
feat(switch_modes): switch between modes plotter -> monitor, vice-versa

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -458,7 +458,7 @@ dependencies = [
 
 [[package]]
 name = "comchan"
-version = "0.9.1"
+version = "0.10.0"
 dependencies = [
  "chrono",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "comchan"
-version = "0.9.1"
+version = "0.10.0"
 edition = "2024"
 authors = ["Vaishnav Sabari Girish <vaishnav.sabari.girish@gmail.com>"]
 license = "MIT"

--- a/src/config.rs
+++ b/src/config.rs
@@ -134,7 +134,7 @@ impl Default for Config {
 #[derive(Parser)]
 #[command(
     name = "comchan",
-    version = "0.9.1",
+    version = "0.10.0",
     author = "Vaishnav-Sabari-Girish",
     about = "Blazingly Fast Minimal Serial Monitor with Plotting"
 )]
@@ -254,6 +254,7 @@ pub struct Args {
 }
 
 /// The resolved, merged configuration used at runtime.
+#[derive(Clone)]
 pub struct MergedConfig {
     pub port: Option<String>,
     pub baud: u32,

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,6 +17,18 @@ use config::{
 use monitor::run_normal_mode;
 use plotter::run_plotter_mode;
 
+pub enum AppExitState {
+    Quit,
+    SwitchToPlotter {
+        port: Option<Box<dyn serialport::SerialPort>>,
+        rtt_reader: Option<crate::rtt_reader::RttDefmtReader>,
+    },
+    SwitchToMonitor {
+        port: Option<Box<dyn serialport::SerialPort>>,
+        rtt_reader: Option<crate::rtt_reader::RttDefmtReader>,
+    },
+}
+
 fn list_available_ports() -> Result<(), Box<dyn std::error::Error>> {
     println!("{color_cyan}󰅍 All Available Serial Ports:{color_reset}");
     let ports = serialport::available_ports()?;
@@ -99,9 +111,31 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         }
     };
 
-    if merged.plot {
-        run_plotter_mode(merged, port_name)
-    } else {
-        run_normal_mode(merged, port_name)
+    let mut is_plot_mode = merged.plot;
+    let mut active_port: Option<Box<dyn serialport::SerialPort>> = None;
+    let mut active_rtt: Option<crate::rtt_reader::RttDefmtReader> = None;
+
+    loop {
+        let result = if is_plot_mode {
+            run_plotter_mode(merged.clone(), port_name.clone(), active_port, active_rtt)
+        } else {
+            run_normal_mode(merged.clone(), port_name.clone(), active_port, active_rtt)
+        };
+
+        match result {
+            Ok(AppExitState::Quit) => break,
+            Ok(AppExitState::SwitchToPlotter { port, rtt_reader }) => {
+                is_plot_mode = true;
+                active_port = port;
+                active_rtt = rtt_reader;
+            }
+            Ok(AppExitState::SwitchToMonitor { port, rtt_reader }) => {
+                is_plot_mode = false;
+                active_port = port;
+                active_rtt = rtt_reader;
+            }
+            Err(e) => return Err(e),
+        }
     }
+    Ok(())
 }

--- a/src/monitor.rs
+++ b/src/monitor.rs
@@ -51,6 +51,32 @@ fn strip_ansi(s: &str) -> String {
     out
 }
 
+macro_rules! poll_ctrl_rx_while_waiting {
+    ($ctrl_rx:expr, $running:expr) => {
+        let range = core::range::Range { start: 0, end: 20 };
+        for _ in range {
+            if let Ok(cmd) = $ctrl_rx.try_recv() {
+                match cmd {
+                    MonitorCommand::SwitchMode => {
+                        terminal::disable_raw_mode().ok();
+                        return Ok(crate::AppExitState::SwitchToPlotter {
+                            port: None,
+                            rtt_reader: None,
+                        });
+                    }
+                    MonitorCommand::Quit => {
+                        println!("\r\n{color_yellow}󰏃 Shutting down ComChan…{color_reset}");
+                        $running.store(false, std::sync::atomic::Ordering::SeqCst);
+                        return Ok(crate::AppExitState::Quit);
+                    }
+                    _ => {}
+                }
+            }
+            thread::sleep(Duration::from_millis(50));
+        }
+    };
+}
+
 pub fn run_normal_mode(
     config: MergedConfig,
     port_name: String,
@@ -185,30 +211,8 @@ pub fn run_normal_mode(
                     print!("\r{color_yellow}⏳ Waiting for RTT target...{color_reset}\x1b[K");
                     io::stdout().flush().ok();
 
-                    let range = core::range::Range { start: 0, end: 20 };
+                    poll_ctrl_rx_while_waiting!(ctrl_rx, running);
 
-                    for _ in range {
-                        if let Ok(cmd) = ctrl_rx.try_recv() {
-                            match cmd {
-                                MonitorCommand::SwitchMode => {
-                                    terminal::disable_raw_mode().ok();
-                                    return Ok(crate::AppExitState::SwitchToPlotter {
-                                        port: None,
-                                        rtt_reader: None,
-                                    });
-                                }
-                                MonitorCommand::Quit => {
-                                    println!(
-                                        "\r\n{color_yellow}󰏃 Shutting down ComChan…{color_reset}"
-                                    );
-                                    running.store(false, std::sync::atomic::Ordering::SeqCst);
-                                    return Ok(crate::AppExitState::Quit);
-                                }
-                                _ => {}
-                            }
-                        }
-                        thread::sleep(Duration::from_millis(50));
-                    }
                     continue;
                 }
             }
@@ -268,30 +272,8 @@ pub fn run_normal_mode(
                     );
                     io::stdout().flush().ok();
 
-                    let range = core::range::Range { start: 0, end: 20 };
+                    poll_ctrl_rx_while_waiting!(ctrl_rx, running);
 
-                    for _ in range {
-                        if let Ok(cmd) = ctrl_rx.try_recv() {
-                            match cmd {
-                                MonitorCommand::SwitchMode => {
-                                    terminal::disable_raw_mode().ok();
-                                    return Ok(crate::AppExitState::SwitchToPlotter {
-                                        port: None,
-                                        rtt_reader: None,
-                                    });
-                                }
-                                MonitorCommand::Quit => {
-                                    println!(
-                                        "\r\n{color_yellow}󰏃 Shutting down ComChan…{color_reset}"
-                                    );
-                                    running.store(false, std::sync::atomic::Ordering::SeqCst);
-                                    return Ok(crate::AppExitState::Quit);
-                                }
-                                _ => {}
-                            }
-                        }
-                        thread::sleep(Duration::from_millis(50));
-                    }
                     continue;
                 }
             }

--- a/src/monitor.rs
+++ b/src/monitor.rs
@@ -17,6 +17,12 @@ use crossterm::{
 
 use pretty_hex::*;
 
+enum MonitorCommand {
+    Repaint(u8),
+    SwitchMode,
+    Quit,
+}
+
 fn strip_ansi(s: &str) -> String {
     let mut out = String::with_capacity(s.len());
 
@@ -48,7 +54,9 @@ fn strip_ansi(s: &str) -> String {
 pub fn run_normal_mode(
     config: MergedConfig,
     port_name: String,
-) -> Result<(), Box<dyn std::error::Error>> {
+    passed_port: Option<Box<dyn serialport::SerialPort>>,
+    passed_rtt: Option<crate::rtt_reader::RttDefmtReader>,
+) -> Result<crate::AppExitState, Box<dyn std::error::Error>> {
     let serial_config = if config.simulate || config.replay_file.is_some() || config.rtt {
         None
     } else {
@@ -93,7 +101,7 @@ pub fn run_normal_mode(
 
     // 2. Setup channels and input thread ONCE
     let (input_tx, input_rx) = mpsc::channel::<String>();
-    let (ctrl_tx, ctrl_rx) = mpsc::channel::<u8>();
+    let (ctrl_tx, ctrl_rx) = mpsc::channel::<MonitorCommand>();
     thread::spawn(move || {
         terminal::enable_raw_mode().ok();
         let mut line_buf = String::new();
@@ -107,9 +115,16 @@ pub fn run_normal_mode(
                         (KeyCode::Char('l'), KeyModifiers::CONTROL) => {
                             print!("\x1bc\x1b[5 q");
                             io::stdout().flush().ok();
-                            ctrl_tx.send(b'\r').ok();
+                            ctrl_tx.send(MonitorCommand::Repaint(b'\r')).ok();
                         }
-                        (KeyCode::Char('c'), KeyModifiers::CONTROL) => break,
+                        (KeyCode::Char('p'), KeyModifiers::CONTROL) => {
+                            ctrl_tx.send(MonitorCommand::SwitchMode).ok();
+                            break;
+                        }
+                        (KeyCode::Char('c'), KeyModifiers::CONTROL) => {
+                            ctrl_tx.send(MonitorCommand::Quit).ok();
+                            break;
+                        }
                         (KeyCode::Enter, _) => {
                             let _ = input_tx.send(line_buf.clone());
                             line_buf.clear();
@@ -136,11 +151,6 @@ pub fn run_normal_mode(
     });
 
     let running = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(true));
-    let r = running.clone();
-    ctrlc::set_handler(move || {
-        println!("\r\n{color_yellow}󰏃 Shutting down ComChan…{color_reset}");
-        r.store(false, std::sync::atomic::Ordering::SeqCst);
-    })?;
 
     let mut buffer = [0u8; 1024];
     let mut last_sent: Option<String> = None;
@@ -149,10 +159,14 @@ pub fn run_normal_mode(
     let mut lines_discarded = 0;
     const DISCARD_COUNT: usize = 5;
 
+    let mut active_port = passed_port;
+    let mut active_rtt = passed_rtt;
     // Connection & Reconnection
     while running.load(std::sync::atomic::Ordering::SeqCst) {
         // Initialize RTT reader
-        let mut rtt_reader = if config.rtt {
+        let mut rtt_reader = if let Some(r) = active_rtt.take() {
+            Some(r)
+        } else if config.rtt {
             let elf = config.elf.as_deref().unwrap_or("");
 
             match RttDefmtReader::new(elf, config.chip.clone()) {
@@ -179,7 +193,9 @@ pub fn run_normal_mode(
         };
 
         // Serial Port
-        let mut port = if config.simulate || config.replay_file.is_some() || config.rtt {
+        let mut port = if let Some(p) = active_port.take() {
+            Some(p)
+        } else if config.simulate || config.replay_file.is_some() || config.rtt {
             None
         } else {
             // Match handles the error instead of returning it
@@ -542,11 +558,23 @@ pub fn run_normal_mode(
             }
 
             // ── Control bytes (e.g. Ctrl+L repaint) ─────────────────────────────
-            if let Ok(byte) = ctrl_rx.try_recv()
-                && let Some(p) = port.as_mut()
-            {
-                let _ = p.write_all(&[byte]);
-                let _ = p.flush();
+            if let Ok(cmd) = ctrl_rx.try_recv() {
+                match cmd {
+                    MonitorCommand::Repaint(byte) => {
+                        if let Some(p) = port.as_mut() {
+                            let _ = p.write_all(&[byte]);
+                            let _ = p.flush();
+                        }
+                    }
+                    MonitorCommand::SwitchMode => {
+                        terminal::disable_raw_mode().ok();
+                        return Ok(crate::AppExitState::SwitchToPlotter { port, rtt_reader });
+                    }
+                    MonitorCommand::Quit => {
+                        println!("\r\n{color_yellow}󰏃 Shutting down ComChan…{color_reset}");
+                        running.store(false, std::sync::atomic::Ordering::SeqCst);
+                    }
+                }
             }
 
             thread::sleep(Duration::from_millis(10));
@@ -555,5 +583,5 @@ pub fn run_normal_mode(
 
     println!("\r\n{color_green} ComChan disconnected cleanly{color_reset}");
     terminal::disable_raw_mode().ok();
-    Ok(())
+    Ok(crate::AppExitState::Quit)
 }

--- a/src/monitor.rs
+++ b/src/monitor.rs
@@ -184,7 +184,31 @@ pub fn run_normal_mode(
                     // Otherwise, treat as a transient hardware/connection error and wait
                     print!("\r{color_yellow}⏳ Waiting for RTT target...{color_reset}\x1b[K");
                     io::stdout().flush().ok();
-                    thread::sleep(Duration::from_millis(1000));
+
+                    let range = core::range::Range { start: 0, end: 20 };
+
+                    for _ in range {
+                        if let Ok(cmd) = ctrl_rx.try_recv() {
+                            match cmd {
+                                MonitorCommand::SwitchMode => {
+                                    terminal::disable_raw_mode().ok();
+                                    return Ok(crate::AppExitState::SwitchToPlotter {
+                                        port: None,
+                                        rtt_reader: None,
+                                    });
+                                }
+                                MonitorCommand::Quit => {
+                                    println!(
+                                        "\r\n{color_yellow}󰏃 Shutting down ComChan…{color_reset}"
+                                    );
+                                    running.store(false, std::sync::atomic::Ordering::SeqCst);
+                                    return Ok(crate::AppExitState::Quit);
+                                }
+                                _ => {}
+                            }
+                        }
+                        thread::sleep(Duration::from_millis(50));
+                    }
                     continue;
                 }
             }
@@ -243,7 +267,31 @@ pub fn run_normal_mode(
                         port_name
                     );
                     io::stdout().flush().ok();
-                    thread::sleep(Duration::from_millis(1000));
+
+                    let range = core::range::Range { start: 0, end: 20 };
+
+                    for _ in range {
+                        if let Ok(cmd) = ctrl_rx.try_recv() {
+                            match cmd {
+                                MonitorCommand::SwitchMode => {
+                                    terminal::disable_raw_mode().ok();
+                                    return Ok(crate::AppExitState::SwitchToPlotter {
+                                        port: None,
+                                        rtt_reader: None,
+                                    });
+                                }
+                                MonitorCommand::Quit => {
+                                    println!(
+                                        "\r\n{color_yellow}󰏃 Shutting down ComChan…{color_reset}"
+                                    );
+                                    running.store(false, std::sync::atomic::Ordering::SeqCst);
+                                    return Ok(crate::AppExitState::Quit);
+                                }
+                                _ => {}
+                            }
+                        }
+                        thread::sleep(Duration::from_millis(50));
+                    }
                     continue;
                 }
             }

--- a/src/plotter.rs
+++ b/src/plotter.rs
@@ -310,8 +310,12 @@ impl PlotterState {
 pub fn run_plotter_mode(
     config: MergedConfig,
     port_name: String,
-) -> Result<(), Box<dyn std::error::Error>> {
-    let mut port = if config.simulate || config.replay_file.is_some() || config.rtt {
+    passed_port: Option<Box<dyn serialport::SerialPort>>,
+    passed_rtt: Option<crate::rtt_reader::RttDefmtReader>,
+) -> Result<crate::AppExitState, Box<dyn std::error::Error>> {
+    let mut port = if let Some(p) = passed_port {
+        Some(p)
+    } else if config.simulate || config.replay_file.is_some() || config.rtt {
         None
     } else {
         let data_bits = parse_data_bits(config.data_bits)?;
@@ -329,7 +333,9 @@ pub fn run_plotter_mode(
                 .open()?,
         )
     };
-    let mut rtt_reader = if config.rtt {
+    let mut rtt_reader = if let Some(r) = passed_rtt {
+        Some(r)
+    } else if config.rtt {
         let elf = config.elf.as_deref().unwrap_or("");
 
         if elf.is_empty() {
@@ -401,6 +407,12 @@ pub fn run_plotter_mode(
                 KeyCode::Char('q') | KeyCode::Esc => break,
                 KeyCode::Char('c') if key.modifiers.contains(KeyModifiers::CONTROL) => break,
 
+                // Switch Modes
+                KeyCode::Char('p') if key.modifiers.contains(KeyModifiers::CONTROL) => {
+                    disable_raw_mode().ok();
+                    execute!(terminal.backend_mut(), LeaveAlternateScreen).ok();
+                    return Ok(crate::AppExitState::SwitchToMonitor { port, rtt_reader });
+                }
                 // Space: pause / resume
                 KeyCode::Char(' ') => {
                     state.paused = !state.paused;
@@ -971,5 +983,5 @@ pub fn run_plotter_mode(
         );
     }
 
-    Ok(())
+    Ok(crate::AppExitState::Quit)
 }


### PR DESCRIPTION
Users can now switch between modes i.e plotter -> monitor and monitor ->
plotter using the `CTRL+P` keybind.

Closes #88

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add in-app switching between Monitor and Plotter with Ctrl+P. Switching keeps the current serial/RTT connection so you don’t reconnect or lose state, and Ctrl+P/C remain responsive during reconnects.

- **New Features**
  - Ctrl+P toggles Monitor ↔ Plotter in both directions.
  - Preserves the active `serialport` handle and RTT reader across switches for seamless transitions.

- **Refactors**
  - Extracted reconnect polling into `poll_ctrl_rx_while_waiting!` to keep input responsive and remove duplicate logic.

<sup>Written for commit 6cb6d6a097295615cab34da833f0fccad40281c4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Vaishnav-Sabari-Girish/ComChan/pull/89?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

