### PR TITLE
feat/3d ratatui wireframe

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -100,6 +100,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "approx"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "arc-swap"
 version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -216,9 +225,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.11.1"
+version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
 dependencies = [
  "serde_core",
 ]
@@ -276,6 +285,12 @@ name = "bumpalo"
 version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
+
+[[package]]
+name = "by_address"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64fa3c856b712db6612c019f14756e64e4bcea13337a6b33b696333a9eaa2d06"
 
 [[package]]
 name = "bytemuck"
@@ -601,6 +616,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "critical-section"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -612,7 +633,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "crossterm_winapi",
  "derive_more",
  "document-features",
@@ -943,7 +964,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "block2",
  "libc",
  "objc2",
@@ -1059,7 +1080,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f5ebc2381d030e4e89183554c3fcd4ad44dc5ab34961ab09e09b4adbe4f94b61"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "csv",
  "deku",
  "md-5 0.10.6",
@@ -1078,7 +1099,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d6712ab7c4bd91d8ff9e09bcb1356e25bf19d191177eaac264db8632707236"
 dependencies = [
  "base64",
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "bytemuck",
  "esp-idf-part",
  "flate2",
@@ -1119,6 +1140,12 @@ dependencies = [
  "bit-set",
  "regex",
 ]
+
+[[package]]
+name = "fast-srgb8"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd2e7510819d6fbf51a5545c8f922716ecfb14df168a3242f7d33e0239efe6a1"
 
 [[package]]
 name = "fdeflate"
@@ -1198,7 +1225,7 @@ version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c7e611d49285d4c4b2e1727b72cf05353558885cc5252f93707b845dfcaf3d3"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "byteorder",
  "core-foundation 0.9.4",
  "core-graphics",
@@ -1421,6 +1448,11 @@ name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
+]
 
 [[package]]
 name = "heapless"
@@ -1833,7 +1865,7 @@ version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f50e8f47623268b5407192d26876c4d7f89d686ca130fdc53bced4814cd29f8"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
 ]
 
 [[package]]
@@ -1874,11 +1906,11 @@ dependencies = [
 
 [[package]]
 name = "lru"
-version = "0.16.4"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f66e8d5d03f609abc3a39e6f08e4164ebf1447a732906d39eb9b99b7919ef39"
+checksum = "8a860605968fce16869fd239cf4237a82f3ac470723415db603b0e8b6c8d4fb9"
 dependencies = [
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
 ]
 
 [[package]]
@@ -2017,7 +2049,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -2030,7 +2062,7 @@ version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -2042,7 +2074,7 @@ version = "0.31.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -2209,6 +2241,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7bb71e1b3fa6ca1c61f383464aaf2bb0e2f8e772a1f01d486832464de363b951"
 dependencies = [
  "num-traits",
+]
+
+[[package]]
+name = "palette"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cbf71184cc5ecc2e4e1baccdb21026c20e5fc3dcf63028a086131b3ab00b6e6"
+dependencies = [
+ "approx",
+ "fast-srgb8",
+ "libm",
+ "palette_derive",
+]
+
+[[package]]
+name = "palette_derive"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5030daf005bface118c096f510ffb781fc28f9ab6a32ab224d8631be6851d30"
+dependencies = [
+ "by_address",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2630,9 +2686,9 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "ratatui"
-version = "0.30.0"
+version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1ce67fb8ba4446454d1c8dbaeda0557ff5e94d39d5e5ed7f10a65eb4c8266bc"
+checksum = "1695748e3a735b34968c887ceea5a380b43545903868ae8f5b666593100f6b68"
 dependencies = [
  "instability",
  "ratatui-core",
@@ -2640,22 +2696,26 @@ dependencies = [
  "ratatui-macros",
  "ratatui-termwiz",
  "ratatui-widgets",
+ "serde",
 ]
 
 [[package]]
 name = "ratatui-core"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ef8dea09a92caaf73bff7adb70b76162e5937524058a7e5bff37869cbbec293"
+checksum = "42d3603f354bba8c595fa47860e60142d7372b7210c27044c6a7d0e1a4336b44"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "compact_str",
- "hashbrown 0.16.1",
+ "critical-section",
+ "hashbrown 0.17.1",
  "indoc",
  "itertools",
  "kasuari",
  "lru",
- "strum 0.27.2",
+ "palette",
+ "serde",
+ "strum 0.28.0",
  "thiserror 2.0.18",
  "unicode-segmentation",
  "unicode-truncate",
@@ -2664,9 +2724,9 @@ dependencies = [
 
 [[package]]
 name = "ratatui-crossterm"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "577c9b9f652b4c121fb25c6a391dd06406d3b092ba68827e6d2f09550edc54b3"
+checksum = "2b2867bedcbd6a690ca4f8672a687b730ec07660c79844517b084311b529980c"
 dependencies = [
  "cfg-if",
  "crossterm",
@@ -2676,9 +2736,9 @@ dependencies = [
 
 [[package]]
 name = "ratatui-macros"
-version = "0.7.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7f1342a13e83e4bb9d0b793d0ea762be633f9582048c892ae9041ef39c936f4"
+checksum = "80fac59720679490d89d200df411faa249be728681adcabed3d047ae72c48f1d"
 dependencies = [
  "ratatui-core",
  "ratatui-widgets",
@@ -2696,9 +2756,9 @@ dependencies = [
 
 [[package]]
 name = "ratatui-termwiz"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f76fe0bd0ed4295f0321b1676732e2454024c15a35d01904ddb315afd3d545c"
+checksum = "386b8ff8f74ed749509391c56d549761a2fcdb408e1f42e467286bcb7dac8967"
 dependencies = [
  "ratatui-core",
  "termwiz",
@@ -2706,18 +2766,19 @@ dependencies = [
 
 [[package]]
 name = "ratatui-widgets"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7dbfa023cd4e604c2553483820c5fe8aa9d71a42eea5aa77c6e7f35756612db"
+checksum = "7ef4f17dd7ac3abf5adc2b920a03c61eee4bfe6a88fa5191936895525371d79c"
 dependencies = [
- "bitflags 2.11.1",
- "hashbrown 0.16.1",
+ "bitflags 2.13.0",
+ "hashbrown 0.17.1",
  "indoc",
  "instability",
  "itertools",
  "line-clipping",
  "ratatui-core",
- "strum 0.27.2",
+ "serde",
+ "strum 0.28.0",
  "time",
  "unicode-segmentation",
  "unicode-width 0.2.2",
@@ -2725,7 +2786,7 @@ dependencies = [
 
 [[package]]
 name = "ratatui-wireframe"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "num-traits",
  "ratatui",
@@ -2739,7 +2800,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
 ]
 
 [[package]]
@@ -2816,7 +2877,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -2967,7 +3028,7 @@ version = "4.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4d91116f97173694f1642263b2ff837f80d933aa837e2314969f6728f661df3"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "cfg-if",
  "core-foundation 0.10.1",
  "core-foundation-sys",
@@ -3186,7 +3247,7 @@ checksum = "4676b37242ccbd1aabf56edb093a4827dc49086c0ffd764a5705899e0f35f8f7"
 dependencies = [
  "anyhow",
  "base64",
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "fancy-regex",
  "filedescriptor",
  "finl_unicode",
@@ -3657,7 +3718,7 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
@@ -4005,7 +4066,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "indexmap",
  "log",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,9 +29,9 @@ object = "0.39.1"
 plotters = "0.3.7"
 pretty-hex = "0.4.2"
 probe-rs = "0.31.0"
-ratatui = "0.30.0"
+ratatui = "0.30.1"
 ratatui-ratty = { version = "0.3.0", optional = true }
-ratatui-wireframe = { version = "0.6.0", path = "crates/ratatui-wireframe" }
+ratatui-wireframe = { version = "0.7.0", path = "crates/ratatui-wireframe", features = ["ratty"] }
 serde = { version = "1.0", features = ["derive"] }
 serialport = "4.9"
 toml = "1.1.2"

--- a/crates/ratatui-wireframe/Cargo.toml
+++ b/crates/ratatui-wireframe/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ratatui-wireframe"
-version = "0.6.0"
+version = "0.7.0"
 edition = "2024"
 authors = ["Vaishnav Sabari Girish <vaishnav.sabari.girish@gmail.com>"]
 license = "MIT"
@@ -20,3 +20,4 @@ wrfm = { version = "0.4.0", default-features = false }
 [features]
 default = ["std"]
 std = ["ratatui/layout-cache"]
+ratty = []

--- a/crates/ratatui-wireframe/README.md
+++ b/crates/ratatui-wireframe/README.md
@@ -31,10 +31,10 @@ Add this to your `Cargo.toml`:
 ```toml
 [dependencies]
 ratatui = "0.26.0"
-ratatui-wireframe = "0.1.0"
+ratatui-wireframe = "0.7.0"
 
 # Or, to enable native .obj file parsing:
-# ratatui-wireframe = { version = "0.1.0", features = ["ratty"] }
+# ratatui-wireframe = { version = "0.7.0", features = ["ratty"] }
 ```
 
 ## Quick Start

--- a/crates/ratatui-wireframe/README.md
+++ b/crates/ratatui-wireframe/README.md
@@ -9,10 +9,16 @@ rotate 3D wireframe models in your terminal.
 
 ## Features
 
-* **Zero-Dependency 3D Rendering:** Uses pure math to project 3D space into
-  terminal Braille characters.
+* **Zero-Dependency 3D Rendering (Braille):** Uses pure math to project 3D space
+  into terminal Braille characters.
+* **3D models rendering via `ratty`**: Uses the `ratatui-ratty` crate and the
+  **Ratty Graphics Protocol** to render actual 3D models from an `.obj` file.
 * **Dynamic Orientation:** Easily pass pitch, yaw, and roll to rotate your
   models in real-time.
+* **Built-in Models:** Comes with default geometric primitives (Cube,
+  Tetrahedron, Octahedron).
+* **Custom Model Loading:** Seamlessly load custom `.wrfm` files, or enable the
+  `ratty` feature to natively parse and render standard 3D `.obj` files!
 * **Integrated Axes:** Includes a built-in stationary X/Y/Z axis triad (gnomon)
   for spatial context.
 * **Adaptive Layout:** Automatically handles aspect ratio scaling to prevent
@@ -26,22 +32,54 @@ Add this to your `Cargo.toml`:
 [dependencies]
 ratatui = "0.26.0"
 ratatui-wireframe = "0.1.0"
+
+# Or, to enable native .obj file parsing:
+# ratatui-wireframe = { version = "0.1.0", features = ["ratty"] }
 ```
 
 ## Quick Start
 
-Simply initialize the `WireframeWidget` in your draw loop with your rotation
-data:
+Initialize a `Model` and pass it to the `WireframeWidget` in your draw loop
+along with your rotation data:
 
 ```rust
-use ratatui_wireframe::WireframeWidget;
+use ratatui_wireframe::{WireframeWidget, model::Model};
+use ratatui::style::Color;
+
+// 1. Select your model (Built-in, .wrfm, or .obj)
+let my_model = Model::cube(); 
 
 // Inside your terminal draw loop:
+// 2. Pass the model and Euler angles (in radians)
 let wireframe = WireframeWidget::new(pitch_rad, yaw_rad, roll_rad)
     .title("3D Telemetry")
-    .color(Color::Cyan);
+    .color(Color::Cyan)
+    .model(my_model);
 
 f.render_widget(wireframe, chunk);
+```
+
+## Loading Custom Models
+
+You can easily load your own 3D shapes.
+
+**Loading a `.wrfm` file (Default):**
+
+```rust
+use wrfm::WrfmModel;
+use ratatui_wireframe::model::Model;
+
+let parsed_wrfm = WrfmModel::from_file("my_drone.wrfm").unwrap();
+let custom_model = Model::from_wrfm(parsed_wrfm);
+```
+
+**Loading a `.obj` file (Requires the `ratty` feature):**
+
+```rust
+use ratatui_wireframe::model::Model;
+
+let obj_data = std::fs::read_to_string("spaceship.obj").unwrap();
+let custom_model = Model::from_obj(&obj_data).unwrap();
 ```
 
 ## How it works

--- a/crates/ratatui-wireframe/src/model.rs
+++ b/crates/ratatui-wireframe/src/model.rs
@@ -17,6 +17,100 @@ impl Model {
         }
     }
 
+    #[cfg(feature = "ratty")]
+    pub fn from_obj(obj_string: &str) -> Result<Self, crate::alloc::string::String> {
+        let mut vertices = Vec::new();
+        let mut edges = Vec::new();
+
+        for (line_num, line) in obj_string.lines().enumerate() {
+            let line = line.trim();
+            if line.is_empty() || line.starts_with('#') {
+                continue;
+            }
+
+            let mut parts = line.split_whitespace();
+            let Some(prefix) = parts.next() else {
+                continue;
+            };
+
+            match prefix {
+                "v" => {
+                    let x = parts
+                        .next()
+                        .and_then(|s| s.parse::<f64>().ok())
+                        .ok_or_else(|| {
+                            crate::alloc::format!("Invalid X on line {}", line_num + 1)
+                        })?;
+                    let y = parts
+                        .next()
+                        .and_then(|s| s.parse::<f64>().ok())
+                        .ok_or_else(|| {
+                            crate::alloc::format!("Invalid Y on line {}", line_num + 1)
+                        })?;
+                    let z = parts
+                        .next()
+                        .and_then(|s| s.parse::<f64>().ok())
+                        .ok_or_else(|| {
+                            crate::alloc::format!("Invalid Z on line {}", line_num + 1)
+                        })?;
+
+                    vertices.push((x, y, z));
+                }
+                "f" | "l" => {
+                    let mut indices = Vec::new();
+                    for part in parts {
+                        let v_str = part.split('/').next().unwrap_or("");
+                        let idx = v_str.parse::<usize>().map_err(|_| {
+                            crate::alloc::format!("Invalid Index on line {}", line_num + 1)
+                        })?;
+
+                        if idx == 0 {
+                            return Err(crate::alloc::format!(
+                                "OBJ indices are 1-based, found 0 on line {}",
+                                line_num + 1
+                            ));
+                        }
+
+                        indices.push(idx - 1);
+                    }
+
+                    if indices.len() >= 2 {
+                        let is_polygon = prefix == "f";
+                        let limit = if is_polygon {
+                            indices.len()
+                        } else {
+                            indices.len() - 1
+                        };
+
+                        let range = core::range::Range {
+                            start: 0,
+                            end: limit,
+                        };
+
+                        for i in range {
+                            let start = indices[i];
+                            let end = indices[(i + 1) % indices.len()];
+
+                            let edge = if start < end {
+                                (start, end)
+                            } else {
+                                (end, start)
+                            };
+
+                            edges.push(edge);
+                        }
+                    }
+                }
+                _ => {}
+            }
+        }
+
+        edges.sort_unstable();
+        edges.dedup();
+
+        Ok(Self { vertices, edges })
+    }
+
     pub fn cube() -> &'static Self {
         static CUBE: Once<Model> = Once::new();
 

--- a/crates/ratatui-wireframe/src/model.rs
+++ b/crates/ratatui-wireframe/src/model.rs
@@ -108,6 +108,15 @@ impl Model {
         edges.sort_unstable();
         edges.dedup();
 
+        if edges
+            .iter()
+            .any(|&(start, end)| start >= vertices.len() || end >= vertices.len())
+        {
+            use alloc::string::ToString;
+
+            return Err("OBJ references undefined vertex index".to_string());
+        }
+
         Ok(Self { vertices, edges })
     }
 

--- a/src/plotter.rs
+++ b/src/plotter.rs
@@ -400,7 +400,7 @@ pub fn run_plotter_mode(
                     Err(e) => state.last_error = Some(format!("Failed to read {}: {}", path, e)),
                 }
             }
-            #[cfg(feature = "ratty")]
+            #[cfg(not(feature = "ratty"))]
             {
                 state.last_error = Some(
                     "OBJ parsing requires the ratty feature. Recompile with --features ratty"

--- a/src/plotter.rs
+++ b/src/plotter.rs
@@ -387,13 +387,36 @@ pub fn run_plotter_mode(
     let mut serial_buf = [0u8; 1024];
 
     if let crate::config::BrailleModel::Custom(ref path) = config.braille {
-        match wrfm::WrfmModel::from_file(path) {
-            Ok(parsed_wrfm) => {
-                let render_model = ratatui_wireframe::model::Model::from_wrfm(parsed_wrfm);
-                state.custom_model = Some(render_model);
+        if path.to_lowercase().ends_with(".obj") {
+            #[cfg(feature = "ratty")]
+            {
+                match std::fs::read_to_string(path) {
+                    Ok(obj_data) => match ratatui_wireframe::model::Model::from_obj(&obj_data) {
+                        Ok(render_model) => state.custom_model = Some(render_model),
+                        Err(e) => {
+                            state.last_error = Some(format!("OBJ Parse Error in {}: {}", path, e))
+                        }
+                    },
+                    Err(e) => state.last_error = Some(format!("Failed to read {}: {}", path, e)),
+                }
             }
-            Err(e) => {
-                state.last_error = Some(format!("Failed to load {}: {}", path, e));
+            #[cfg(feature = "ratty")]
+            {
+                state.last_error = Some(
+                    "OBJ parsing requires the ratty feature. Recompile with --features ratty"
+                        .to_string(),
+                );
+            }
+        } else {
+            // ── Route to the legacy .wrfm parser ──
+            match wrfm::WrfmModel::from_file(path) {
+                Ok(parsed_wrfm) => {
+                    let render_model = ratatui_wireframe::model::Model::from_wrfm(parsed_wrfm);
+                    state.custom_model = Some(render_model);
+                }
+                Err(e) => {
+                    state.last_error = Some(format!("Failed to load {}: {}", path, e));
+                }
             }
         }
     }


### PR DESCRIPTION
Users can now use the `ratatui-wireframe` crate to view 3D models too via the **Ratty Graphics Protocol** by enabling the `ratty` feature when adding `ratatui-wireframe`

```bash
cargo add ratatui-wireframe --features ratty
```

Closes #90

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add native `.obj` model rendering to `ratatui-wireframe` behind the `ratty` feature and wire it into the plotter with auto-detection. Also hardens OBJ parsing with stricter index bounds checks and edge de-dup to avoid crashes on malformed files.

- **New Features**
  - Added `Model::from_obj(&str)` behind the `ratty` feature in `ratatui-wireframe`.
  - Plotter auto-detects `.obj` files and loads them when built with `--features ratty`; shows a helpful hint if not enabled.

- **Migration**
  - To use `.obj` models: add `ratatui-wireframe` with the `ratty` feature and build with `--features ratty`.
  - Existing `.wrfm` models work unchanged.

<sup>Written for commit 2a103ef79ad1caf0a3abfb399a7e642b2dc38ea6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Vaishnav-Sabari-Girish/ComChan/pull/91?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

