### PR TITLE
feat/side by side

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -571,7 +571,7 @@ dependencies = [
 
 [[package]]
 name = "comchan"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "btleplug",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "comchan"
-version = "0.11.0"
+version = "0.12.0"
 edition = "2024"
 authors = ["Vaishnav Sabari Girish <vaishnav.sabari.girish@gmail.com>"]
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -32,12 +32,14 @@ cargo install comchan
 # Install with Hardware-Accelerated 3D support (Ratty Terminal) and BLE
 cargo install comchan --features ratty,ble
 
+
 ```
 
 Verify the installation:
 
 ```bash
 comchan --version
+
 
 ```
 
@@ -59,6 +61,7 @@ yay -S comchan-ratty
 ## Using paru
 paru -S comchan-ratty
 
+
 ```
 
 ### The Binary
@@ -70,6 +73,7 @@ cargo binstall comchan
 # AUR 
 yay -S comchan-bin
 paru -S comchan-bin
+
 ```
 
 > [!NOTE]
@@ -83,11 +87,12 @@ paru -S comchan-bin
 [`elda`](https://github.com/Mjoyufull/Elda)
 
 ```bash
-elda i https://github.com/Vaishnav-Sabari-Girish/ComChan
+elda i [https://github.com/Vaishnav-Sabari-Girish/ComChan](https://github.com/Vaishnav-Sabari-Girish/ComChan)
+
 ```
 
 > [!NOTE]
-> Credits for `elda` go to [**Rikona**](https://github.com/Mjoyufull)
+> Credits for `elda` go to **[Rikona](https://github.com/Mjoyufull)**
 
 ### From source
 
@@ -95,11 +100,12 @@ Build from source for the latest development version:
 
 ```bash
 # Clone from GitHub
-git clone https://github.com/Vaishnav-Sabari-Girish/ComChan.git
+git clone [https://github.com/Vaishnav-Sabari-Girish/ComChan.git](https://github.com/Vaishnav-Sabari-Girish/ComChan.git)
 
 # Build and run with all features
 cd ComChan
 cargo run --release --features ble,ratty -- --version
+
 
 ```
 
@@ -124,6 +130,7 @@ Options:
   -V, --version                       Print version
   # ... (and many more)
 
+
 ```
 
 ---
@@ -139,6 +146,7 @@ ComChan supports streaming data wirelessly from BLE-enabled embedded devices
 # Start ComChan in BLE mode to scan and connect to a peripheral
 comchan --ble
 
+
 ```
 
 ComChan will scan for devices, prompt you to select your target, and
@@ -151,7 +159,28 @@ stream is active.
 ```bash
 comchan -p /dev/ttyUSB0 -r 115200
 
+
 ```
+
+### Dual Monitor Side-by-Side View
+
+Monitor two serial ports simultaneously in a split-pane TUI. Perfect for
+debugging UART/CAN bridges or inter-microcontroller communication.
+
+```bash
+comchan -p /dev/ttyUSB0 /dev/ttyUSB1 -r 115200
+
+# Test it out using the built-in simulator!
+comchan --simulate -p mock1 mock2
+
+```
+
+> [!TIP]
+> The dual monitor features independent pane auto-scrolling. Press `?` at any
+> time to open the interactive help modal for shortcuts to switch active panes,
+> scroll through history, and more. Logging (`--log`) and CSV streaming
+> (`--csv`) will also automatically split into two separate files to prevent
+> data mixing!
 
 ### RTT & Defmt Debug Probe Mode
 
@@ -160,6 +189,7 @@ directly from your microcontroller's memory via SWD.
 
 ```bash
 comchan --rtt --elf path/to/firmware.elf --chip nRF52840_xxAA
+
 
 ```
 
@@ -171,6 +201,7 @@ Line Chart and the 3D Telemetry Dashboard.
 ```bash
 comchan --port /dev/ttyUSB0 --baud 115200 --plot
 
+
 ```
 
 ---
@@ -180,22 +211,24 @@ comchan --port /dev/ttyUSB0 --baud 115200 --plot
 ### Current Features ✅
 
 * **BLE Support** - Stream data wirelessly via Nordic UART Service (NUS).
+* **Dual Monitor Side-by-Side View** - View two serial ports simultaneously in a
+  split-pane TUI with independent scrollbars and auto-split logging.
 * **Read & Write Serial Data** - Monitor incoming data and send commands.
 * **Instant Mode Hot-Swapping** - Seamlessly toggle between Monitor and Plotter
-  via `Ctrl+P`.
+via `Ctrl+P`.
 * **RTT & Defmt Support** - Stream logs via SWD/J-Link directly from memory.
 * **Auto-Recovery & Graceful Exit** - Robust handling of connection drops and
-  hardware resets.
+hardware resets.
 * **Terminal-Based Serial Plotter** - Visualize sensor values with auto-scaling.
 * **3D Spatial Telemetry (IMU)** - Real-time 3D rotation dashboard.
 * **Real-Time Session Replay** - Replay previously recorded `.log` or `.csv`
-  files.
+files.
 * **Continuous CSV Streaming** - Stream parsed numeric data to CSV on-the-fly.
 * **Hex Dump View** - Inspect raw binary payloads with `--hex` or
-  `--hex-pretty`.
+`--hex-pretty`.
 * **Export Plot to SVG** - Save visualizations as high-quality SVGs.
 * **Hardware Simulation** - Generate mock sensor data for testing without
-  hardware.
+hardware.
 
 ## Stargazers over time (Graph)
 

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ paru -S comchan-bin
 [`elda`](https://github.com/Mjoyufull/Elda)
 
 ```bash
-elda i [https://github.com/Vaishnav-Sabari-Girish/ComChan](https://github.com/Vaishnav-Sabari-Girish/ComChan)
+elda i https://github.com/Vaishnav-Sabari-Girish/ComChan
 
 ```
 
@@ -100,7 +100,7 @@ Build from source for the latest development version:
 
 ```bash
 # Clone from GitHub
-git clone [https://github.com/Vaishnav-Sabari-Girish/ComChan.git](https://github.com/Vaishnav-Sabari-Girish/ComChan.git)
+git clone https://github.com/Vaishnav-Sabari-Girish/ComChan.git
 
 # Build and run with all features
 cd ComChan

--- a/code_tests/side_side/bharat_chat/bharat_chat.ino
+++ b/code_tests/side_side/bharat_chat/bharat_chat.ino
@@ -1,0 +1,33 @@
+#include <HardwareSerial.h>
+
+// Initialize Hardware UART 2
+HardwareSerial commSerial(2); 
+
+// Standard ESP32 UART2 pins
+#define RX_PIN 16
+#define TX_PIN 17
+
+void setup() {
+  // Start the hardware serial for your PC console
+  Serial.begin(115200);
+  
+  // Start UART2 at 9600 baud, 8 data bits, no parity, 1 stop bit
+  commSerial.begin(9600, SERIAL_8N1, RX_PIN, TX_PIN);
+  
+  Serial.println("\n--- Bharat Pi UART Chat Started ---");
+  Serial.println("Type here to send to ESP8266.");
+}
+
+void loop() {
+  // If data comes FROM the ESP8266, print it to the PC
+  if (commSerial.available()) {
+    char c = commSerial.read();
+    Serial.write(c);
+  }
+
+  // If you type data IN the PC console, send it to the ESP8266
+  if (Serial.available()) {
+    char c = Serial.read();
+    commSerial.write(c);
+  }
+}

--- a/code_tests/side_side/bharat_chat/sketch.yaml
+++ b/code_tests/side_side/bharat_chat/sketch.yaml
@@ -1,0 +1,1 @@
+default_fqbn: esp32:esp32:esp32

--- a/code_tests/side_side/esp8266_chat/esp8266_chat.ino
+++ b/code_tests/side_side/esp8266_chat/esp8266_chat.ino
@@ -1,0 +1,29 @@
+#include <SoftwareSerial.h>
+
+// RX = D1 (GPIO 5), TX = D2 (GPIO 4)
+SoftwareSerial commSerial(5, 4); 
+
+void setup() {
+  // Start the hardware serial for your PC console (picocom)
+  Serial.begin(115200);
+  
+  // Start the software serial to talk to the Bharat Pi
+  commSerial.begin(9600);
+  
+  Serial.println("\n--- ESP8266 UART Chat Started ---");
+  Serial.println("Type here to send to Bharat Pi.");
+}
+
+void loop() {
+  // If data comes FROM the Bharat Pi, print it to the PC
+  if (commSerial.available()) {
+    char c = commSerial.read();
+    Serial.write(c);
+  }
+
+  // If you type data IN the PC console, send it to the Bharat Pi
+  if (Serial.available()) {
+    char c = Serial.read();
+    commSerial.write(c);
+  }
+}

--- a/code_tests/side_side/esp8266_chat/sketch.yaml
+++ b/code_tests/side_side/esp8266_chat/sketch.yaml
@@ -1,0 +1,1 @@
+default_fqbn: esp8266:esp8266:nodemcuv2

--- a/src/config.rs
+++ b/src/config.rs
@@ -136,7 +136,7 @@ impl Default for Config {
 #[derive(Parser)]
 #[command(
     name = "comchan",
-    version = "0.11.0",
+    version = "0.12.0",
     author = "Vaishnav-Sabari-Girish",
     about = "Blazingly Fast Minimal Serial Monitor with Plotting"
 )]
@@ -144,8 +144,8 @@ pub struct Args {
     #[arg(long = "completions", value_enum, help = "Generate Shell completions")]
     pub completions: Option<GenShell>,
 
-    #[arg(short = 'p', long = "port", help = "Serial port to connect to")]
-    pub port: Option<String>,
+    #[arg(short = 'p', long = "port", help = "Serial port(s) to connect to", num_args = 1..=2)]
+    pub port: Option<Vec<String>>,
 
     #[arg(short = 'r', long = "baud", help = "Baud Rate of the Serial Monitor")]
     pub baud: Option<u32>,
@@ -261,7 +261,7 @@ pub struct Args {
 /// The resolved, merged configuration used at runtime.
 #[derive(Clone)]
 pub struct MergedConfig {
-    pub port: Option<String>,
+    pub port: Option<Vec<String>>,
     pub baud: u32,
     pub data_bits: u8,
     pub stop_bits: u8,
@@ -438,7 +438,7 @@ pub fn generate_default_config(path: Option<PathBuf>) -> Result<(), Box<dyn std:
 
 pub fn merge_config_and_args(config: Config, args: Args) -> MergedConfig {
     MergedConfig {
-        port: args.port.or(config.port),
+        port: args.port.or_else(|| config.port.map(|p| vec![p])),
         baud: args.baud.or(config.baud).unwrap_or(9600),
         data_bits: args.data_bits.or(config.data_bits).unwrap_or(8),
         stop_bits: args.stop_bits.or(config.stop_bits).unwrap_or(1),

--- a/src/dual_ports.rs
+++ b/src/dual_ports.rs
@@ -172,7 +172,7 @@ fn spawn_serial_thread(
                                 .write_all(payload.as_bytes())
                                 .and_then(|_| port.flush())
                             {
-                                let _ = tx.send(wrap_event(format!("Write Error: {}", e)));
+                                let _ = tx.send(wrap_error(format!("Write Error: {}", e)));
                             } else {
                                 let _ = tx.send(wrap_event(format!("TX: {}\n", cmd)));
                             }
@@ -348,6 +348,9 @@ pub fn run_dual_mode(
                                 let _ = tx_cmd2.send(cmd);
                             }
                         }
+                    }
+                    KeyCode::Char('c') if key.modifiers.contains(event::KeyModifiers::CONTROL) => {
+                        break;
                     }
                     KeyCode::Char(c) => {
                         if app_state.active_pane == 0 {

--- a/src/dual_ports.rs
+++ b/src/dual_ports.rs
@@ -22,10 +22,20 @@ use std::sync::mpsc;
 use std::thread;
 use std::time::Duration;
 
+struct TerminalCleanup;
+
+impl Drop for TerminalCleanup {
+    fn drop(&mut self) {
+        let _ = disable_raw_mode();
+        let _ = execute!(io::stdout(), LeaveAlternateScreen);
+    }
+}
+
 pub enum DualEvent {
     Port1(String),
     Port2(String),
-    Error(String),
+    Error1(String),
+    Error2(String),
 }
 
 struct DualMonitorState {
@@ -66,6 +76,75 @@ fn split_filename(base_path: &Option<String>, suffix: &str) -> Option<String> {
             format!("{}_{}.{}", stem, suffix, ext)
         }
     })
+}
+
+fn spawn_serial_thread(
+    port_name: String,
+    cfg: MergedConfig,
+    tx: mpsc::Sender<DualEvent>,
+    is_port1: bool,
+) {
+    thread::spawn(move || {
+        let wrap_event = |text: String| {
+            if is_port1 {
+                DualEvent::Port1(text)
+            } else {
+                DualEvent::Port2(text)
+            }
+        };
+        let wrap_error = |err: String| {
+            if is_port1 {
+                DualEvent::Error1(err)
+            } else {
+                DualEvent::Error2(err)
+            }
+        };
+
+        if cfg.simulate {
+            let mut counter = 0;
+            loop {
+                let text = format!(
+                    "SIM [Port {}]: Packet {}\n",
+                    if is_port1 { 1 } else { 2 },
+                    counter
+                );
+                let _ = tx.send(wrap_event(text));
+                counter += 1;
+                thread::sleep(Duration::from_millis(500));
+            }
+        } else {
+            let _data_bits = parse_data_bits(cfg.data_bits).unwrap();
+            let _stop_bits = parse_stop_bits(cfg.stop_bits).unwrap();
+            let _parity = parse_parity(&cfg.parity).unwrap();
+            let _flow_control = parse_flow_control(&cfg.flow_control).unwrap();
+
+            match serialport::new(&port_name, cfg.baud)
+                // ... [chain your config] ...
+                .open()
+            {
+                Ok(mut port) => {
+                    let mut buffer = [0; 1024];
+                    loop {
+                        match port.read(&mut buffer) {
+                            Ok(n) if n > 0 => {
+                                let _ = tx.send(wrap_event(
+                                    String::from_utf8_lossy(&buffer[..n]).into_owned(),
+                                ));
+                            }
+                            Err(e) if e.kind() != io::ErrorKind::TimedOut => {
+                                let _ = tx.send(wrap_error(format!("Read Error: {}", e)));
+                                break;
+                            }
+                            _ => {}
+                        }
+                    }
+                }
+                Err(e) => {
+                    let _ = tx.send(wrap_error(format!("Failed to open {}: {}", port_name, e)));
+                }
+            }
+        }
+    });
 }
 
 pub fn run_dual_mode(
@@ -109,118 +188,14 @@ pub fn run_dual_mode(
     let p1_name = port1_name.clone();
     let cfg1 = config.clone();
 
-    thread::spawn(move || {
-        if cfg1.simulate {
-            let mut counter = 0;
-            loop {
-                let simulated_text = format!(
-                    "SIM [Port 1]: Temp: {:.2} C, Hum: {}\n",
-                    25.0 + (counter as f32 * 0.1),
-                    40 + (counter % 20)
-                );
-                let _ = tx1.send(DualEvent::Port1(simulated_text));
-                counter += 1;
-                thread::sleep(Duration::from_millis(500));
-            }
-        } else {
-            let data_bits = parse_data_bits(cfg1.data_bits).unwrap();
-            let stop_bits = parse_stop_bits(cfg1.stop_bits).unwrap();
-            let parity = parse_parity(&cfg1.parity).unwrap();
-            let flow_control = parse_flow_control(&cfg1.flow_control).unwrap();
-
-            match serialport::new(&p1_name, cfg1.baud)
-                .timeout(Duration::from_millis(cfg1.timeout_ms))
-                .data_bits(data_bits)
-                .stop_bits(stop_bits)
-                .parity(parity)
-                .flow_control(flow_control)
-                .open()
-            {
-                Ok(mut port) => {
-                    let mut buffer = [0; 1024];
-                    loop {
-                        match port.read(&mut buffer) {
-                            Ok(n) if n > 0 => {
-                                let text = String::from_utf8_lossy(&buffer[..n]).to_string();
-                                let _ = tx1.send(DualEvent::Port1(text));
-                            }
-                            Ok(_) => {}
-                            Err(ref e) if e.kind() == io::ErrorKind::TimedOut => {}
-                            Err(e) => {
-                                let _ = tx1.send(DualEvent::Error(format!("Port 1 Error: {}", e)));
-                                break;
-                            }
-                        }
-                    }
-                }
-                Err(e) => {
-                    let _ = tx1.send(DualEvent::Error(format!(
-                        "Failed to open {}: {}",
-                        p1_name, e
-                    )));
-                }
-            }
-        }
-    });
+    spawn_serial_thread(p1_name, cfg1, tx1, true);
 
     // Serial port 2 thread
     let tx2 = tx.clone();
     let p2_name = port2_name.clone();
     let cfg2 = config.clone();
 
-    thread::spawn(move || {
-        if cfg2.simulate {
-            let mut counter = 0;
-            loop {
-                let simulated_text = format!(
-                    "SIM [Port 2]: Temp: {:.2} C, Hum: {}\n",
-                    25.0 + (counter as f32 * 0.1),
-                    40 + (counter % 20)
-                );
-                let _ = tx2.send(DualEvent::Port2(simulated_text));
-                counter += 1;
-                thread::sleep(Duration::from_millis(500));
-            }
-        } else {
-            let data_bits = parse_data_bits(cfg2.data_bits).unwrap();
-            let stop_bits = parse_stop_bits(cfg2.stop_bits).unwrap();
-            let parity = parse_parity(&cfg2.parity).unwrap();
-            let flow_control = parse_flow_control(&cfg2.flow_control).unwrap();
-
-            match serialport::new(&p2_name, cfg2.baud)
-                .timeout(Duration::from_millis(cfg2.timeout_ms))
-                .data_bits(data_bits)
-                .stop_bits(stop_bits)
-                .parity(parity)
-                .flow_control(flow_control)
-                .open()
-            {
-                Ok(mut port) => {
-                    let mut buffer = [0; 1024];
-                    loop {
-                        match port.read(&mut buffer) {
-                            Ok(n) if n > 0 => {
-                                let text = String::from_utf8_lossy(&buffer[..n]).to_string();
-                                let _ = tx2.send(DualEvent::Port2(text));
-                            }
-                            Ok(_) => {}
-                            Err(ref e) if e.kind() == io::ErrorKind::TimedOut => {}
-                            Err(e) => {
-                                let _ = tx2.send(DualEvent::Error(format!("Port 2 Error: {}", e)));
-                                break;
-                            }
-                        }
-                    }
-                }
-                Err(e) => {
-                    let _ = tx2.send(DualEvent::Error(format!(
-                        "Failed to open {}: {}",
-                        p2_name, e
-                    )));
-                }
-            }
-        }
-    });
+    spawn_serial_thread(p2_name, cfg2, tx2, false);
 
     // TUI
     enable_raw_mode()?;
@@ -228,6 +203,7 @@ pub fn run_dual_mode(
     let mut stdout = io::stdout();
     execute!(stdout, EnterAlternateScreen)?;
     let backend = CrosstermBackend::new(stdout);
+    let _cleanup = TerminalCleanup;
     let mut terminal = Terminal::new(backend)?;
 
     let mut app_state = DualMonitorState::new();
@@ -274,19 +250,19 @@ pub fn run_dual_mode(
                     }
                 }
 
-                DualEvent::Error(err) => {
-                    app_state.port1_logs.push(format!("ERROR: {}", err));
-                    app_state.port2_logs.push(format!("ERROR: {}", err));
-                }
+                DualEvent::Error1(err) => app_state.port1_logs.push(format!("ERROR: {}", err)),
+                DualEvent::Error2(err) => app_state.port2_logs.push(format!("ERROR: {}", err)),
             }
         }
 
         // Limit memory to prevent RAM exhaustion
         if app_state.port1_logs.len() > 2000 {
             app_state.port1_logs.drain(0..500);
+            app_state.scroll1 = app_state.scroll1.saturating_sub(500);
         }
         if app_state.port2_logs.len() > 2000 {
             app_state.port2_logs.drain(0..500);
+            app_state.scroll2 = app_state.scroll2.saturating_sub(500);
         }
 
         // Handle Input
@@ -475,8 +451,6 @@ pub fn run_dual_mode(
     }
 
     // Cleanup
-    disable_raw_mode()?;
-    execute!(terminal.backend_mut(), LeaveAlternateScreen)?;
     Ok(crate::AppExitState::Quit)
 }
 

--- a/src/dual_ports.rs
+++ b/src/dual_ports.rs
@@ -113,13 +113,17 @@ fn spawn_serial_thread(
                 thread::sleep(Duration::from_millis(500));
             }
         } else {
-            let _data_bits = parse_data_bits(cfg.data_bits).unwrap();
-            let _stop_bits = parse_stop_bits(cfg.stop_bits).unwrap();
-            let _parity = parse_parity(&cfg.parity).unwrap();
-            let _flow_control = parse_flow_control(&cfg.flow_control).unwrap();
+            let data_bits = parse_data_bits(cfg.data_bits).unwrap();
+            let stop_bits = parse_stop_bits(cfg.stop_bits).unwrap();
+            let parity = parse_parity(&cfg.parity).unwrap();
+            let flow_control = parse_flow_control(&cfg.flow_control).unwrap();
 
             match serialport::new(&port_name, cfg.baud)
-                // ... [chain your config] ...
+                .timeout(Duration::from_millis(cfg.timeout_ms))
+                .data_bits(data_bits)
+                .stop_bits(stop_bits)
+                .parity(parity)
+                .flow_control(flow_control)
                 .open()
             {
                 Ok(mut port) => {

--- a/src/dual_ports.rs
+++ b/src/dual_ports.rs
@@ -1,0 +1,501 @@
+use crate::config::MergedConfig;
+use crate::serial::{parse_data_bits, parse_flow_control, parse_parity, parse_stop_bits};
+use crossterm::{
+    event::{self, Event, KeyCode, KeyEventKind},
+    execute,
+    terminal::{EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode, enable_raw_mode},
+};
+use ratatui::layout::{Alignment, Rect};
+use ratatui::widgets::Clear;
+use ratatui::{
+    Terminal,
+    backend::CrosstermBackend,
+    layout::{Constraint, Direction, Layout},
+    style::{Color, Modifier, Style},
+    text::Line,
+    widgets::{Block, Borders, Paragraph, Scrollbar, ScrollbarOrientation, ScrollbarState},
+};
+use std::fs::OpenOptions;
+use std::io::{self, BufWriter, Read, Write};
+use std::path::Path;
+use std::sync::mpsc;
+use std::thread;
+use std::time::Duration;
+
+pub enum DualEvent {
+    Port1(String),
+    Port2(String),
+    Error(String),
+}
+
+struct DualMonitorState {
+    port1_logs: Vec<String>,
+    port2_logs: Vec<String>,
+    scroll1: usize,
+    scroll2: usize,
+    active_pane: u8, // 0 for left and 1 for right
+    auto_scroll1: bool,
+    auto_scroll2: bool,
+    show_help: bool,
+}
+
+impl DualMonitorState {
+    fn new() -> Self {
+        Self {
+            port1_logs: Vec::new(),
+            port2_logs: Vec::new(),
+            scroll1: 0,
+            scroll2: 0,
+            active_pane: 0,
+            auto_scroll1: true,
+            auto_scroll2: true,
+            show_help: false,
+        }
+    }
+}
+
+fn split_filename(base_path: &Option<String>, suffix: &str) -> Option<String> {
+    base_path.as_ref().map(|path_str| {
+        let path = Path::new(path_str);
+        let stem = path.file_stem().unwrap_or_default().to_string_lossy();
+        let ext = path.extension().unwrap_or_default().to_string_lossy();
+
+        if ext.is_empty() {
+            format!("{}_{}", stem, suffix)
+        } else {
+            format!("{}_{}.{}", stem, suffix, ext)
+        }
+    })
+}
+
+pub fn run_dual_mode(
+    config: MergedConfig,
+    ports: Vec<String>,
+) -> Result<crate::AppExitState, Box<dyn std::error::Error>> {
+    let port1_name = ports[0].clone();
+    let port2_name = ports[1].clone();
+
+    // Split logging and CSV
+    let log1_path = split_filename(&config.log_file, "port1");
+    let log2_path = split_filename(&config.log_file, "port2");
+
+    let csv1_path = split_filename(&config.csv_file, "port1");
+    let csv2_path = split_filename(&config.csv_file, "port2");
+
+    let mut log1_writer = log1_path.and_then(|p| {
+        OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(p)
+            .ok()
+            .map(BufWriter::new)
+    });
+    let mut log2_writer = log2_path.and_then(|p| {
+        OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(p)
+            .ok()
+            .map(BufWriter::new)
+    });
+
+    let mut csv1_streamer = csv1_path.and_then(|p| crate::export::CsvStreamer::new(&p).ok());
+    let mut csv2_streamer = csv2_path.and_then(|p| crate::export::CsvStreamer::new(&p).ok());
+
+    let (tx, rx) = mpsc::channel::<DualEvent>();
+
+    // Serial port 1 thread
+    let tx1 = tx.clone();
+    let p1_name = port1_name.clone();
+    let cfg1 = config.clone();
+
+    thread::spawn(move || {
+        if cfg1.simulate {
+            let mut counter = 0;
+            loop {
+                let simulated_text = format!(
+                    "SIM [Port 1]: Temp: {:.2} C, Hum: {}\n",
+                    25.0 + (counter as f32 * 0.1),
+                    40 + (counter % 20)
+                );
+                let _ = tx1.send(DualEvent::Port1(simulated_text));
+                counter += 1;
+                thread::sleep(Duration::from_millis(500));
+            }
+        } else {
+            let data_bits = parse_data_bits(cfg1.data_bits).unwrap();
+            let stop_bits = parse_stop_bits(cfg1.stop_bits).unwrap();
+            let parity = parse_parity(&cfg1.parity).unwrap();
+            let flow_control = parse_flow_control(&cfg1.flow_control).unwrap();
+
+            match serialport::new(&p1_name, cfg1.baud)
+                .timeout(Duration::from_millis(cfg1.timeout_ms))
+                .data_bits(data_bits)
+                .stop_bits(stop_bits)
+                .parity(parity)
+                .flow_control(flow_control)
+                .open()
+            {
+                Ok(mut port) => {
+                    let mut buffer = [0; 1024];
+                    loop {
+                        match port.read(&mut buffer) {
+                            Ok(n) if n > 0 => {
+                                let text = String::from_utf8_lossy(&buffer[..n]).to_string();
+                                let _ = tx1.send(DualEvent::Port1(text));
+                            }
+                            Ok(_) => {}
+                            Err(ref e) if e.kind() == io::ErrorKind::TimedOut => {}
+                            Err(e) => {
+                                let _ = tx1.send(DualEvent::Error(format!("Port 1 Error: {}", e)));
+                                break;
+                            }
+                        }
+                    }
+                }
+                Err(e) => {
+                    let _ = tx1.send(DualEvent::Error(format!(
+                        "Failed to open {}: {}",
+                        p1_name, e
+                    )));
+                }
+            }
+        }
+    });
+
+    // Serial port 2 thread
+    let tx2 = tx.clone();
+    let p2_name = port2_name.clone();
+    let cfg2 = config.clone();
+
+    thread::spawn(move || {
+        if cfg2.simulate {
+            let mut counter = 0;
+            loop {
+                let simulated_text = format!(
+                    "SIM [Port 2]: Temp: {:.2} C, Hum: {}\n",
+                    25.0 + (counter as f32 * 0.1),
+                    40 + (counter % 20)
+                );
+                let _ = tx2.send(DualEvent::Port2(simulated_text));
+                counter += 1;
+                thread::sleep(Duration::from_millis(500));
+            }
+        } else {
+            let data_bits = parse_data_bits(cfg2.data_bits).unwrap();
+            let stop_bits = parse_stop_bits(cfg2.stop_bits).unwrap();
+            let parity = parse_parity(&cfg2.parity).unwrap();
+            let flow_control = parse_flow_control(&cfg2.flow_control).unwrap();
+
+            match serialport::new(&p2_name, cfg2.baud)
+                .timeout(Duration::from_millis(cfg2.timeout_ms))
+                .data_bits(data_bits)
+                .stop_bits(stop_bits)
+                .parity(parity)
+                .flow_control(flow_control)
+                .open()
+            {
+                Ok(mut port) => {
+                    let mut buffer = [0; 1024];
+                    loop {
+                        match port.read(&mut buffer) {
+                            Ok(n) if n > 0 => {
+                                let text = String::from_utf8_lossy(&buffer[..n]).to_string();
+                                let _ = tx2.send(DualEvent::Port2(text));
+                            }
+                            Ok(_) => {}
+                            Err(ref e) if e.kind() == io::ErrorKind::TimedOut => {}
+                            Err(e) => {
+                                let _ = tx2.send(DualEvent::Error(format!("Port 2 Error: {}", e)));
+                                break;
+                            }
+                        }
+                    }
+                }
+                Err(e) => {
+                    let _ = tx2.send(DualEvent::Error(format!(
+                        "Failed to open {}: {}",
+                        p2_name, e
+                    )));
+                }
+            }
+        }
+    });
+
+    // TUI
+    enable_raw_mode()?;
+
+    let mut stdout = io::stdout();
+    execute!(stdout, EnterAlternateScreen)?;
+    let backend = CrosstermBackend::new(stdout);
+    let mut terminal = Terminal::new(backend)?;
+
+    let mut app_state = DualMonitorState::new();
+    let mut buf1 = String::new();
+    let mut buf2 = String::new();
+
+    loop {
+        while let Ok(event) = rx.try_recv() {
+            match event {
+                DualEvent::Port1(text) => {
+                    buf1.push_str(&text);
+                    while let Some(pos) = buf1.find('\n') {
+                        let line = buf1.drain(..=pos).collect::<String>();
+                        let clean = line.trim_end().to_string();
+                        if !clean.is_empty() {
+                            app_state.port1_logs.push(clean.clone());
+                            if let Some(ref mut w) = log1_writer {
+                                let _ = writeln!(w, "{}", clean);
+                                let _ = w.flush();
+                            }
+                            if let Some(ref mut csv) = csv1_streamer {
+                                let readings = crate::parser::parse_sensor_data(&clean);
+                                let _ = csv.write_row(&readings);
+                            }
+                        }
+                    }
+                }
+                DualEvent::Port2(text) => {
+                    buf2.push_str(&text);
+                    while let Some(pos) = buf2.find('\n') {
+                        let line = buf2.drain(..=pos).collect::<String>();
+                        let clean = line.trim_end().to_string();
+                        if !clean.is_empty() {
+                            app_state.port2_logs.push(clean.clone());
+                            if let Some(ref mut w) = log2_writer {
+                                let _ = writeln!(w, "{}", clean);
+                                let _ = w.flush();
+                            }
+                            if let Some(ref mut csv) = csv2_streamer {
+                                let readings = crate::parser::parse_sensor_data(&clean);
+                                let _ = csv.write_row(&readings);
+                            }
+                        }
+                    }
+                }
+
+                DualEvent::Error(err) => {
+                    app_state.port1_logs.push(format!("ERROR: {}", err));
+                    app_state.port2_logs.push(format!("ERROR: {}", err));
+                }
+            }
+        }
+
+        // Limit memory to prevent RAM exhaustion
+        if app_state.port1_logs.len() > 2000 {
+            app_state.port1_logs.drain(0..500);
+        }
+        if app_state.port2_logs.len() > 2000 {
+            app_state.port2_logs.drain(0..500);
+        }
+
+        // Handle Input
+        if event::poll(Duration::from_millis(16))?
+            && let Event::Key(key) = event::read()?
+            && key.kind == KeyEventKind::Press
+        {
+            if app_state.show_help {
+                app_state.show_help = false;
+                continue;
+            }
+
+            match key.code {
+                KeyCode::Char('?') => app_state.show_help = true,
+                KeyCode::Char('q') | KeyCode::Esc => break,
+                KeyCode::Char('c') if key.modifiers.contains(event::KeyModifiers::CONTROL) => break,
+                KeyCode::Left => app_state.active_pane = 0,
+                KeyCode::Right => app_state.active_pane = 1,
+                KeyCode::Tab => {
+                    if app_state.active_pane == 0 {
+                        app_state.active_pane = 1;
+                    } else {
+                        app_state.active_pane = 0;
+                    }
+                }
+                KeyCode::Up => {
+                    if app_state.active_pane == 0 {
+                        app_state.scroll1 = app_state.scroll1.saturating_sub(1);
+                        app_state.auto_scroll1 = false;
+                    } else {
+                        app_state.scroll2 = app_state.scroll2.saturating_sub(1);
+                        app_state.auto_scroll2 = false;
+                    }
+                }
+                KeyCode::Down => {
+                    if app_state.active_pane == 0 {
+                        app_state.scroll1 = app_state.scroll1.saturating_add(1);
+                    } else {
+                        app_state.scroll2 = app_state.scroll2.saturating_add(1);
+                    }
+                }
+
+                // Snap to bottom
+                KeyCode::Enter => {
+                    if app_state.active_pane == 0 {
+                        app_state.scroll1 = app_state.port1_logs.len();
+                        app_state.auto_scroll1 = true;
+                    } else {
+                        app_state.scroll2 = app_state.port2_logs.len();
+                        app_state.auto_scroll2 = true;
+                    }
+                }
+                _ => {}
+            }
+        }
+
+        terminal.draw(|f| {
+            let root_layout = Layout::default()
+                .direction(Direction::Vertical)
+                .constraints([Constraint::Min(0), Constraint::Length(1)])
+                .split(f.area());
+
+            let chunks = Layout::default()
+                .direction(Direction::Horizontal)
+                .constraints([Constraint::Percentage(50), Constraint::Percentage(50)])
+                .split(root_layout[0]);
+
+            let active_style = Style::default()
+                .fg(Color::Yellow)
+                .add_modifier(Modifier::BOLD);
+            let inactive_style = Style::default().fg(Color::DarkGray);
+
+            let p1_style = if app_state.active_pane == 0 {
+                active_style
+            } else {
+                inactive_style
+            };
+            let p2_style = if app_state.active_pane == 1 {
+                active_style
+            } else {
+                inactive_style
+            };
+
+            // Pane 1 render
+            let content1 = app_state.port1_logs.join("\n");
+            let lines1 = app_state.port1_logs.len();
+
+            // Auto-scroll
+            let max_scroll1 = lines1.saturating_sub(chunks[0].height.saturating_sub(2) as usize);
+            if app_state.auto_scroll1 || app_state.scroll1 >= max_scroll1 {
+                app_state.scroll1 = max_scroll1;
+                app_state.auto_scroll1 = true;
+            }
+
+            let mut scrollbar_state1 = ScrollbarState::default()
+                .content_length(max_scroll1)
+                .position(app_state.scroll1);
+
+            let block1 = Block::default()
+                .title(format!(" Port 1 {} ", port1_name))
+                .borders(Borders::ALL)
+                .border_style(p1_style);
+
+            let paragraph1 = Paragraph::new(content1)
+                .block(block1)
+                .scroll((app_state.scroll1 as u16, 0));
+
+            f.render_widget(paragraph1, chunks[0]);
+            f.render_stateful_widget(
+                Scrollbar::default()
+                    .orientation(ScrollbarOrientation::VerticalRight)
+                    .begin_symbol(Some("↑"))
+                    .end_symbol(Some("↓")),
+                chunks[0],
+                &mut scrollbar_state1,
+            );
+
+            // Pane 2 render
+            let content2 = app_state.port2_logs.join("\n");
+            let lines2 = app_state.port2_logs.len();
+
+            // Auto-scroll
+            let max_scroll2 = lines2.saturating_sub(chunks[1].height.saturating_sub(2) as usize);
+            if app_state.auto_scroll2 || app_state.scroll2 >= max_scroll2 {
+                app_state.scroll2 = max_scroll2;
+                app_state.auto_scroll2 = true;
+            }
+
+            let mut scrollbar_state2 = ScrollbarState::default()
+                .content_length(max_scroll2)
+                .position(app_state.scroll2);
+
+            let block2 = Block::default()
+                .title(format!(" Port 2 {} ", port2_name))
+                .borders(Borders::ALL)
+                .border_style(p2_style);
+
+            let paragraph2 = Paragraph::new(content2)
+                .block(block2)
+                .scroll((app_state.scroll2 as u16, 0));
+
+            f.render_widget(paragraph2, chunks[1]);
+            f.render_stateful_widget(
+                Scrollbar::default()
+                    .orientation(ScrollbarOrientation::VerticalRight)
+                    .begin_symbol(Some("↑"))
+                    .end_symbol(Some("↓")),
+                chunks[1],
+                &mut scrollbar_state2,
+            );
+
+            let hint_text = Line::from(" Press '?' for help ")
+                .style(Style::default().fg(Color::Cyan))
+                .alignment(Alignment::Center);
+
+            f.render_widget(Paragraph::new(hint_text), root_layout[1]);
+
+            if app_state.show_help {
+                let area = centered_rect(50, 50, f.area());
+
+                let help_text = vec![
+                    Line::from(""),
+                    Line::from(" [?]          : Show / Hide this menu"),
+                    Line::from(" [Tab]        : Toggle active pane (Left/Right)"),
+                    Line::from(" [←] / [→]    : Select active pane"),
+                    Line::from(" [↑] / [↓]    : Scroll active pane & pause auto-scroll"),
+                    Line::from(" [Enter]      : Jump to bottom & resume auto-scroll"),
+                    Line::from(" [q] or [Esc] : Quit Dual Monitor"),
+                    Line::from(" [Ctrl+C]     : Force Quit"),
+                    Line::from(""),
+                    Line::from(" Press any key to close... ")
+                        .style(Style::default().fg(Color::DarkGray)),
+                ];
+
+                f.render_widget(Clear, area);
+
+                let help_block = Paragraph::new(help_text).block(
+                    Block::default()
+                        .title(" Dual Monitor Shortcuts ")
+                        .borders(Borders::ALL)
+                        .border_style(Style::default().fg(Color::Cyan)),
+                );
+                f.render_widget(help_block, area);
+            }
+        })?;
+    }
+
+    // Cleanup
+    disable_raw_mode()?;
+    execute!(terminal.backend_mut(), LeaveAlternateScreen)?;
+    Ok(crate::AppExitState::Quit)
+}
+
+fn centered_rect(percent_x: u16, percent_y: u16, r: Rect) -> Rect {
+    let popup_layout = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Percentage((100 - percent_y) / 2),
+            Constraint::Percentage(percent_y),
+            Constraint::Percentage((100 - percent_y) / 2),
+        ])
+        .split(r);
+
+    Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints([
+            Constraint::Percentage((100 - percent_x) / 2),
+            Constraint::Percentage(percent_x),
+            Constraint::Percentage((100 - percent_x) / 2),
+        ])
+        .split(popup_layout[1])[1]
+}

--- a/src/dual_ports.rs
+++ b/src/dual_ports.rs
@@ -113,10 +113,34 @@ fn spawn_serial_thread(
                 thread::sleep(Duration::from_millis(500));
             }
         } else {
-            let data_bits = parse_data_bits(cfg.data_bits).unwrap();
-            let stop_bits = parse_stop_bits(cfg.stop_bits).unwrap();
-            let parity = parse_parity(&cfg.parity).unwrap();
-            let flow_control = parse_flow_control(&cfg.flow_control).unwrap();
+            let data_bits = match parse_data_bits(cfg.data_bits) {
+                Ok(v) => v,
+                Err(e) => {
+                    let _ = tx.send(wrap_error(format!("Config error: {}", e)));
+                    return;
+                }
+            };
+            let stop_bits = match parse_stop_bits(cfg.stop_bits) {
+                Ok(v) => v,
+                Err(e) => {
+                    let _ = tx.send(wrap_error(format!("Config error: {}", e)));
+                    return;
+                }
+            };
+            let parity = match parse_parity(&cfg.parity) {
+                Ok(v) => v,
+                Err(e) => {
+                    let _ = tx.send(wrap_error(format!("Config error: {}", e)));
+                    return;
+                }
+            };
+            let flow_control = match parse_flow_control(&cfg.flow_control) {
+                Ok(v) => v,
+                Err(e) => {
+                    let _ = tx.send(wrap_error(format!("Config error: {}", e)));
+                    return;
+                }
+            };
 
             match serialport::new(&port_name, cfg.baud)
                 .timeout(Duration::from_millis(cfg.timeout_ms))

--- a/src/dual_ports.rs
+++ b/src/dual_ports.rs
@@ -6,6 +6,7 @@ use crossterm::{
     terminal::{EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode, enable_raw_mode},
 };
 use ratatui::layout::{Alignment, Rect};
+use ratatui::text::Span;
 use ratatui::widgets::Clear;
 use ratatui::{
     Terminal,
@@ -47,6 +48,9 @@ struct DualMonitorState {
     auto_scroll1: bool,
     auto_scroll2: bool,
     show_help: bool,
+    input_mode: bool,
+    input1: String,
+    input2: String,
 }
 
 impl DualMonitorState {
@@ -60,6 +64,9 @@ impl DualMonitorState {
             auto_scroll1: true,
             auto_scroll2: true,
             show_help: false,
+            input_mode: false,
+            input1: String::new(),
+            input2: String::new(),
         }
     }
 }
@@ -82,6 +89,7 @@ fn spawn_serial_thread(
     port_name: String,
     cfg: MergedConfig,
     tx: mpsc::Sender<DualEvent>,
+    rx_cmd: mpsc::Receiver<String>,
     is_port1: bool,
 ) {
     thread::spawn(move || {
@@ -103,6 +111,9 @@ fn spawn_serial_thread(
         if cfg.simulate {
             let mut counter = 0;
             loop {
+                while let Ok(cmd) = rx_cmd.try_recv() {
+                    let _ = tx.send(wrap_event(format!("TX: {}\n", cmd)));
+                }
                 let text = format!(
                     "SIM [Port {}]: Packet {}\n",
                     if is_port1 { 1 } else { 2 },
@@ -151,8 +162,22 @@ fn spawn_serial_thread(
                 .open()
             {
                 Ok(mut port) => {
+                    let _ = port.write_data_terminal_ready(true);
                     let mut buffer = [0; 1024];
                     loop {
+                        // Drain commands
+                        while let Ok(cmd) = rx_cmd.try_recv() {
+                            let payload = format!("{}\r\n", cmd);
+                            if let Err(e) = port
+                                .write_all(payload.as_bytes())
+                                .and_then(|_| port.flush())
+                            {
+                                let _ = tx.send(wrap_event(format!("Write Error: {}", e)));
+                            } else {
+                                let _ = tx.send(wrap_event(format!("TX: {}\n", cmd)));
+                            }
+                        }
+
                         match port.read(&mut buffer) {
                             Ok(n) if n > 0 => {
                                 let _ = tx.send(wrap_event(
@@ -179,6 +204,9 @@ pub fn run_dual_mode(
     config: MergedConfig,
     ports: Vec<String>,
 ) -> Result<crate::AppExitState, Box<dyn std::error::Error>> {
+    let (tx_cmd1, rx_cmd1) = mpsc::channel::<String>();
+    let (tx_cmd2, rx_cmd2) = mpsc::channel::<String>();
+
     let port1_name = ports[0].clone();
     let port2_name = ports[1].clone();
 
@@ -216,14 +244,14 @@ pub fn run_dual_mode(
     let p1_name = port1_name.clone();
     let cfg1 = config.clone();
 
-    spawn_serial_thread(p1_name, cfg1, tx1, true);
+    spawn_serial_thread(p1_name, cfg1, tx1, rx_cmd1, true);
 
     // Serial port 2 thread
     let tx2 = tx.clone();
     let p2_name = port2_name.clone();
     let cfg2 = config.clone();
 
-    spawn_serial_thread(p2_name, cfg2, tx2, false);
+    spawn_serial_thread(p2_name, cfg2, tx2, rx_cmd2, false);
 
     // TUI
     enable_raw_mode()?;
@@ -303,9 +331,47 @@ pub fn run_dual_mode(
                 continue;
             }
 
+            if app_state.input_mode {
+                match key.code {
+                    KeyCode::Esc => app_state.input_mode = false, // Visual Mode (No typing)
+                    KeyCode::Enter => {
+                        let cmd = if app_state.active_pane == 0 {
+                            app_state.input1.drain(..).collect::<String>()
+                        } else {
+                            app_state.input2.drain(..).collect::<String>()
+                        };
+
+                        if !cmd.is_empty() {
+                            if app_state.active_pane == 0 {
+                                let _ = tx_cmd1.send(cmd);
+                            } else {
+                                let _ = tx_cmd2.send(cmd);
+                            }
+                        }
+                    }
+                    KeyCode::Char(c) => {
+                        if app_state.active_pane == 0 {
+                            app_state.input1.push(c);
+                        } else {
+                            app_state.input2.push(c);
+                        }
+                    }
+                    KeyCode::Backspace => {
+                        if app_state.active_pane == 0 {
+                            app_state.input1.pop();
+                        } else {
+                            app_state.input2.pop();
+                        }
+                    }
+                    _ => {}
+                }
+                continue;
+            }
+
             match key.code {
+                KeyCode::Char('i') => app_state.input_mode = true,
                 KeyCode::Char('?') => app_state.show_help = true,
-                KeyCode::Char('q') | KeyCode::Esc => break,
+                KeyCode::Char('q') => break,
                 KeyCode::Char('c') if key.modifiers.contains(event::KeyModifiers::CONTROL) => break,
                 KeyCode::Left => app_state.active_pane = 0,
                 KeyCode::Right => app_state.active_pane = 1,
@@ -358,6 +424,16 @@ pub fn run_dual_mode(
                 .constraints([Constraint::Percentage(50), Constraint::Percentage(50)])
                 .split(root_layout[0]);
 
+            let pane1_layout = Layout::default()
+                .direction(Direction::Vertical)
+                .constraints([Constraint::Min(0), Constraint::Length(3)])
+                .split(chunks[0]);
+
+            let pane2_layout = Layout::default()
+                .direction(Direction::Vertical)
+                .constraints([Constraint::Min(0), Constraint::Length(3)])
+                .split(chunks[1]);
+
             let active_style = Style::default()
                 .fg(Color::Yellow)
                 .add_modifier(Modifier::BOLD);
@@ -375,7 +451,6 @@ pub fn run_dual_mode(
             };
 
             // Pane 1 render
-            let content1 = app_state.port1_logs.join("\n");
             let lines1 = app_state.port1_logs.len();
 
             // Auto-scroll
@@ -394,22 +469,54 @@ pub fn run_dual_mode(
                 .borders(Borders::ALL)
                 .border_style(p1_style);
 
-            let paragraph1 = Paragraph::new(content1)
+            let lines1: Vec<Line> = app_state
+                .port1_logs
+                .iter()
+                .map(|log| {
+                    if log.starts_with("TX:") {
+                        Line::from(Span::styled(log, Style::default().fg(Color::Cyan)))
+                    } else if log.starts_with("ERROR:") {
+                        Line::from(Span::styled(log, Style::default().fg(Color::Red)))
+                    } else {
+                        Line::from(log.as_str())
+                    }
+                })
+                .collect();
+
+            let paragraph1 = Paragraph::new(lines1)
                 .block(block1)
                 .scroll((app_state.scroll1 as u16, 0));
 
-            f.render_widget(paragraph1, chunks[0]);
+            f.render_widget(paragraph1, pane1_layout[0]);
             f.render_stateful_widget(
                 Scrollbar::default()
                     .orientation(ScrollbarOrientation::VerticalRight)
                     .begin_symbol(Some("↑"))
                     .end_symbol(Some("↓")),
-                chunks[0],
+                pane1_layout[0],
                 &mut scrollbar_state1,
             );
 
+            // Input box
+            let mut disp1 = app_state.input1.clone();
+            let input_style1 = if app_state.active_pane == 0 && app_state.input_mode {
+                disp1.push('█');
+                Style::default().fg(Color::Cyan)
+            } else {
+                Style::default().fg(Color::DarkGray)
+            };
+
+            f.render_widget(
+                Paragraph::new(disp1).block(
+                    Block::default()
+                        .borders(Borders::ALL)
+                        .title(" TX (Press 'i' to type) ")
+                        .border_style(input_style1),
+                ),
+                pane1_layout[1],
+            );
+
             // Pane 2 render
-            let content2 = app_state.port2_logs.join("\n");
             let lines2 = app_state.port2_logs.len();
 
             // Auto-scroll
@@ -428,18 +535,51 @@ pub fn run_dual_mode(
                 .borders(Borders::ALL)
                 .border_style(p2_style);
 
-            let paragraph2 = Paragraph::new(content2)
+            let lines2: Vec<Line> = app_state
+                .port2_logs
+                .iter()
+                .map(|log| {
+                    if log.starts_with("TX:") {
+                        Line::from(Span::styled(log, Style::default().fg(Color::Cyan)))
+                    } else if log.starts_with("ERROR:") {
+                        Line::from(Span::styled(log, Style::default().fg(Color::Red)))
+                    } else {
+                        Line::from(log.as_str())
+                    }
+                })
+                .collect();
+
+            let paragraph2 = Paragraph::new(lines2)
                 .block(block2)
                 .scroll((app_state.scroll2 as u16, 0));
 
-            f.render_widget(paragraph2, chunks[1]);
+            f.render_widget(paragraph2, pane2_layout[0]);
             f.render_stateful_widget(
                 Scrollbar::default()
                     .orientation(ScrollbarOrientation::VerticalRight)
                     .begin_symbol(Some("↑"))
                     .end_symbol(Some("↓")),
-                chunks[1],
+                pane2_layout[0],
                 &mut scrollbar_state2,
+            );
+
+            // Input box
+            let mut disp2 = app_state.input2.clone();
+            let input_style2 = if app_state.active_pane == 1 && app_state.input_mode {
+                disp2.push('█');
+                Style::default().fg(Color::Cyan)
+            } else {
+                Style::default().fg(Color::DarkGray)
+            };
+
+            f.render_widget(
+                Paragraph::new(disp2).block(
+                    Block::default()
+                        .borders(Borders::ALL)
+                        .title(" TX (Press 'i' to type) ")
+                        .border_style(input_style2),
+                ),
+                pane2_layout[1],
             );
 
             let hint_text = Line::from(" Press '?' for help ")
@@ -457,8 +597,10 @@ pub fn run_dual_mode(
                     Line::from(" [Tab]        : Toggle active pane (Left/Right)"),
                     Line::from(" [←] / [→]    : Select active pane"),
                     Line::from(" [↑] / [↓]    : Scroll active pane & pause auto-scroll"),
+                    Line::from(" [i]          : Enter typing mode"),
+                    Line::from(" [Esc]        : Exit typing mode"),
                     Line::from(" [Enter]      : Jump to bottom & resume auto-scroll"),
-                    Line::from(" [q] or [Esc] : Quit Dual Monitor"),
+                    Line::from(" [q]          : Quit Dual Monitor"),
                     Line::from(" [Ctrl+C]     : Force Quit"),
                     Line::from(""),
                     Line::from(" Press any key to close... ")

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,7 @@ use clap::Parser;
 use inline_colorization::*;
 
 mod config;
+mod dual_ports;
 mod export;
 mod monitor;
 mod parser;
@@ -79,6 +80,19 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         return list_available_ports();
     }
 
+    // ── CHECK FOR DUAL PORT MODE FIRST ────────────────────────────────────────
+    // Allow dual UI for standard serial and simulate modes. We disable it for
+    // Replay, RTT, and BLE as those use specialized single-stream setups.
+    if merged.replay_file.is_none()
+        && !merged.rtt
+        && !merged.ble
+        && let Some(ports) = &merged.port
+        && ports.len() == 2
+    {
+        crate::dual_ports::run_dual_mode(merged.clone(), ports.clone())?;
+        return Ok(());
+    }
+
     let port_name = if merged.simulate || merged.replay_file.is_some() || merged.rtt || merged.ble {
         if merged.rtt {
             println!("{color_magenta}Starting in RTT/DEFMT debug probe mode....{color_reset}");
@@ -91,31 +105,32 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             "SIMULATE_PORT".to_string()
         }
     } else {
-        match &merged.port {
-            Some(p) if p.to_lowercase() == "auto" => match port_finder::find_usb_port()? {
+        let first_port = merged
+            .port
+            .as_ref()
+            .and_then(|v| v.first())
+            .cloned()
+            .unwrap_or_else(|| "auto".to_string());
+
+        if first_port.to_lowercase() == "auto" {
+            match port_finder::find_usb_port()? {
                 Some(detected) => {
                     println!(
-                        "{color_green} Auto-detected USB port: {}{color_reset}",
+                        "{color_green} Auto-detected USB Port: {}{color_reset}",
                         detected
                     );
                     detected
                 }
                 None => {
+                    eprintln!("{color_red} No USB serial ports found{color_reset}");
                     eprintln!(
-                        "{color_red}No USB serial ports found for auto-detection{color_reset}"
+                        "{color_yellow} Try --list-ports to see available ports{color_reset}"
                     );
-                    eprintln!("{color_yellow}Try --list-ports to see available ports{color_reset}");
                     std::process::exit(1);
                 }
-            },
-            Some(p) => p.clone(),
-            None => {
-                eprintln!(
-                    "{color_red}❌ No port specified. Use --port <PORT>, --auto, or set port in config{color_reset}"
-                );
-                eprintln!("{color_yellow}󰌵 Try --list-ports or --generate-config{color_reset}");
-                std::process::exit(1);
             }
+        } else {
+            first_port
         }
     };
 

--- a/src/monitor.rs
+++ b/src/monitor.rs
@@ -190,6 +190,8 @@ pub fn run_normal_mode(
                         (KeyCode::Enter, _) => {
                             let _ = input_tx.send(line_buf.clone());
                             line_buf.clear();
+                            print!("\r\n");
+                            io::stdout().flush().ok();
                         }
                         (KeyCode::Backspace, _) => {
                             line_buf.pop();
@@ -283,10 +285,18 @@ pub fn run_normal_mode(
                     let _ = p.flush();
 
                     if config.zephyr {
-                        thread::sleep(Duration::from_millis(100));
-                        let _ = p.write_all(b"shell echo off\r");
-                        let _ = p.flush();
-                        thread::sleep(Duration::from_millis(100));
+                        let mut suppress = false;
+                        if let Some(ref sent) = last_sent {
+                            let clean_acc = strip_ansi(&line_acc).trim().to_string();
+                            if clean_acc == *sent {
+                                suppress = true;
+                                last_sent = None;
+                                line_acc.clear();
+                            }
+                        }
+                        if suppress {
+                            continue;
+                        }
                     }
 
                     println!(
@@ -520,20 +530,7 @@ pub fn run_normal_mode(
 
                         let text = String::from_utf8_lossy(raw);
 
-                        // ── Echo suppression ─────────────────────────────────────────
                         line_acc.push_str(&text);
-                        let mut suppress = false;
-                        if let Some(ref sent) = last_sent {
-                            let clean_acc = strip_ansi(&line_acc).trim().to_string();
-                            if clean_acc == *sent {
-                                suppress = true;
-                                last_sent = None;
-                                line_acc.clear();
-                            }
-                        }
-                        if suppress {
-                            continue;
-                        }
 
                         // ── Verbose timestamp prefix ─────────────────────────────────
                         if config.verbose {

--- a/src/plotter.rs
+++ b/src/plotter.rs
@@ -13,7 +13,7 @@ use inline_colorization::*;
 use ratatui::{
     Terminal,
     backend::CrosstermBackend,
-    layout::{Constraint, Direction, Layout},
+    layout::{Constraint, Direction, Layout, Rect},
     prelude::*,
     style::{Color, Modifier, Style},
     symbols,
@@ -65,6 +65,27 @@ fn detect_terminal() -> String {
     "Standard TTY (Braille)".to_string()
 }
 
+/// Helper to create a centered rectangle for modals
+fn centered_rect(percent_x: u16, percent_y: u16, r: Rect) -> Rect {
+    let popup_layout = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Percentage((100 - percent_y) / 2),
+            Constraint::Percentage(percent_y),
+            Constraint::Percentage((100 - percent_y) / 2),
+        ])
+        .split(r);
+
+    Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints([
+            Constraint::Percentage((100 - percent_x) / 2),
+            Constraint::Percentage(percent_x),
+            Constraint::Percentage((100 - percent_x) / 2),
+        ])
+        .split(popup_layout[1])[1]
+}
+
 // ── Plotter state ─────────────────────────────────────────────────────────────
 struct PlotterState {
     sensors: HashMap<String, SensorData>,
@@ -102,6 +123,8 @@ struct PlotterState {
 
     #[cfg(feature = "ratty")]
     ratty_engines: Option<RattyGraphic<'static>>,
+
+    show_help: bool,
 }
 
 const DISCARD_FIRST_LINES: usize = 3;
@@ -189,6 +212,8 @@ impl PlotterState {
 
             #[cfg(feature = "ratty")]
             ratty_engines,
+
+            show_help: false,
         }
     }
 
@@ -431,7 +456,13 @@ pub fn run_plotter_mode(
         if event::poll(Duration::from_millis(5))?
             && let event::Event::Key(key) = event::read()?
         {
+            if state.show_help {
+                state.show_help = false;
+                continue;
+            }
+
             match key.code {
+                KeyCode::Char('?') => state.show_help = true,
                 KeyCode::Char('q') | KeyCode::Esc => break,
                 KeyCode::Char('c') if key.modifiers.contains(KeyModifiers::CONTROL) => break,
 
@@ -1026,7 +1057,7 @@ pub fn run_plotter_mode(
                         .add_modifier(Modifier::BOLD),
                 ),
                 Span::styled(
-                    "  [Space] pause  [c] clear  [1/2/Tab] views  [q/Esc] quit [Ctrl + s] Export",
+                    "  Press '?' for help ",
                     Style::default().fg(Color::DarkGray),
                 ),
             ]);
@@ -1040,6 +1071,39 @@ pub fn run_plotter_mode(
                 .style(Style::default().bg(status_bg));
 
             f.render_widget(status_bar, outer[1]);
+
+            // ── Render Help Modal (Draw last so it stays on top) ──
+            if state.show_help {
+                let area = centered_rect(50, 50, f.area());
+
+                let help_text = vec![
+                    Line::from(""),
+                    Line::from(" [?]          : Show / Hide this menu"),
+                    Line::from(" [1] / [2]    : Switch between 2D Chart / 3D Wireframe"),
+                    Line::from(" [Tab]        : Toggle views"),
+                    Line::from(" [Space]      : Pause / Resume data flow"),
+                    Line::from(" [c]          : Clear all plotter data"),
+                    Line::from(" [Ctrl+S]     : Export 2D Chart to SVG"),
+                    Line::from(" [Ctrl+P]     : Switch back to standard CLI Monitor"),
+                    Line::from(" [q] or [Esc] : Quit Plotter"),
+                    Line::from(" [Ctrl+C]     : Force Quit"),
+                    Line::from(""),
+                    Line::from(" Press any key to close... ")
+                        .style(Style::default().fg(Color::DarkGray)),
+                ];
+
+                // Clear background
+                f.render_widget(Clear, area);
+
+                let help_block = Paragraph::new(help_text).block(
+                    Block::default()
+                        .title(" Plotter Shortcuts ")
+                        .borders(Borders::ALL)
+                        .border_style(Style::default().fg(Color::Cyan)),
+                );
+
+                f.render_widget(help_block, area);
+            }
         })?;
     }
 

--- a/src/plotter.rs
+++ b/src/plotter.rs
@@ -1092,12 +1092,14 @@ pub fn run_plotter_mode(
                 // Clear background
                 f.render_widget(Clear, area);
 
-                let help_block = Paragraph::new(help_text).block(
-                    Block::default()
-                        .title(" Plotter Shortcuts ")
-                        .borders(Borders::ALL)
-                        .border_style(Style::default().fg(Color::Cyan)),
-                );
+                let help_block = Paragraph::new(help_text)
+                    .block(
+                        Block::default()
+                            .title(" Plotter Shortcuts ")
+                            .borders(Borders::ALL)
+                            .border_style(Style::default().fg(Color::Cyan)),
+                    )
+                    .wrap(ratatui::widgets::Wrap { trim: false });
 
                 f.render_widget(help_block, area);
             }

--- a/src/plotter.rs
+++ b/src/plotter.rs
@@ -1056,10 +1056,7 @@ pub fn run_plotter_mode(
                         .fg(Color::Magenta)
                         .add_modifier(Modifier::BOLD),
                 ),
-                Span::styled(
-                    "  Press '?' for help ",
-                    Style::default().fg(Color::DarkGray),
-                ),
+                Span::styled("  Press '?' for help ", Style::default().fg(Color::Cyan)),
             ]);
 
             let status_bar = Paragraph::new(status_line)


### PR DESCRIPTION
Add side-by-side dual monitor TUI and help modals. 

This allows users to view serial logs from 2 serial ports side-by-side instead of having to open multiple terminals. 

Closes #94

![gif](https://vhs.charm.sh/vhs-4IiHwoabnJjkYCEp83Ikr6.gif)

<img width="1132" height="716" alt="side" src="https://github.com/user-attachments/assets/ab09e4fe-382d-4f15-bb80-ed3a9e03b978" />




<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a side-by-side dual monitor TUI to view two serial ports at once, with per-pane TX input, independent scrolling, split logs/CSV, and an in-app help modal. Also adds `?` help to the Plotter, improves TX reliability and error reporting, and bumps to v0.12.0.

- **New Features**
  - Dual split-pane TUI: run with `-p PORT1 PORT2` (also works with `--simulate`); not used for BLE/RTT/Replay.
  - Per-pane TX input: press `i` to type, `Enter` to send, `Esc` to exit; `Tab`/arrow keys switch panes; `?` opens help in Dual and Plotter.
  - Logs/CSV auto-split into `port1`/`port2` files.

- **Bug Fixes**
  - Apply serial settings before opening; invalid data bits/parity/stop bits/flow control now report errors instead of panicking.
  - Fixed routing where Port 2 text appeared in Port 1; TX/ERROR use native colorized spans to avoid TUI artifacts.
  - More reliable TX: assert DTR, append `\r\n`, and flush writes; monitor: fixed newline buffering on `Enter` and refined Zephyr echo suppression.
  - Dual monitor: `Ctrl+C` now force-quits even in typing mode; serial write failures are emitted as Error events (correct styling/CSV).
  - Plotter: fixed Ratty GPU bleed when switching back to the 2D chart.

<sup>Written for commit 4f3c4229e9fe59e0983bd88f922f49b6b98ee2de. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Vaishnav-Sabari-Girish/ComChan/pull/95?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



