### PR TITLE
fix/defmt timestamp

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -571,7 +571,7 @@ dependencies = [
 
 [[package]]
 name = "comchan"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "btleplug",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "comchan"
-version = "0.12.0"
+version = "0.13.0"
 edition = "2024"
 authors = ["Vaishnav Sabari Girish <vaishnav.sabari.girish@gmail.com>"]
 license = "MIT"

--- a/src/config.rs
+++ b/src/config.rs
@@ -136,7 +136,7 @@ impl Default for Config {
 #[derive(Parser)]
 #[command(
     name = "comchan",
-    version = "0.13.0",
+    version,
     author = "Vaishnav-Sabari-Girish",
     about = "Blazingly Fast Minimal Serial Monitor with Plotting"
 )]

--- a/src/config.rs
+++ b/src/config.rs
@@ -136,7 +136,7 @@ impl Default for Config {
 #[derive(Parser)]
 #[command(
     name = "comchan",
-    version = "0.12.0",
+    version = "0.13.0",
     author = "Vaishnav-Sabari-Girish",
     about = "Blazingly Fast Minimal Serial Monitor with Plotting"
 )]

--- a/src/monitor.rs
+++ b/src/monitor.rs
@@ -215,8 +215,13 @@ pub fn run_normal_mode(
                             }
                             (KeyCode::Backspace, _) => {
                                 if cursor_pos > 0 {
+                                    let byte_offset = line_buf
+                                        .char_indices()
+                                        .nth(cursor_pos - 1)
+                                        .map(|(i, _)| i)
+                                        .unwrap();
+                                    line_buf.remove(byte_offset);
                                     cursor_pos -= 1;
-                                    line_buf.remove(cursor_pos);
                                     needs_redraw = true;
                                 }
                             }
@@ -259,7 +264,12 @@ pub fn run_normal_mode(
                                 }
                             }
                             (KeyCode::Char(c), _) => {
-                                line_buf.insert(cursor_pos, c);
+                                let byte_offset = line_buf
+                                    .char_indices()
+                                    .nth(cursor_pos)
+                                    .map(|(i, _)| i)
+                                    .unwrap_or(line_buf.len());
+                                line_buf.insert(byte_offset, c);
                                 cursor_pos += 1;
                                 needs_redraw = true;
                             }

--- a/src/monitor.rs
+++ b/src/monitor.rs
@@ -11,8 +11,9 @@ use std::thread;
 use std::time::Duration;
 
 use crossterm::{
+    cursor,
     event::{self, Event, KeyCode, KeyEvent, KeyModifiers},
-    terminal,
+    execute, terminal,
 };
 
 use pretty_hex::*;
@@ -164,47 +165,134 @@ pub fn run_normal_mode(
     // 2. Setup channels and input thread ONCE
     let (input_tx, input_rx) = mpsc::channel::<String>();
     let (ctrl_tx, ctrl_rx) = mpsc::channel::<MonitorCommand>();
+
     thread::spawn(move || {
         terminal::enable_raw_mode().ok();
+
+        // ── Line editing state ──
         let mut line_buf = String::new();
+        let mut cursor_pos: usize = 0;
+        let mut history: Vec<String> = Vec::new();
+        let mut history_idx: usize = 0;
 
         loop {
             if event::poll(Duration::from_millis(10)).unwrap_or(false) {
                 match event::read() {
                     Ok(Event::Key(KeyEvent {
                         code, modifiers, ..
-                    })) => match (code, modifiers) {
-                        (KeyCode::Char('l'), KeyModifiers::CONTROL) => {
-                            print!("\x1bc\x1b[5 q");
+                    })) => {
+                        let mut needs_redraw = false;
+
+                        let old_cursor_pos = cursor_pos;
+                        let old_len = line_buf.len();
+
+                        match (code, modifiers) {
+                            (KeyCode::Char('l'), KeyModifiers::CONTROL) => {
+                                print!("\x1bc\x1b[5 q");
+                                io::stdout().flush().ok();
+                                ctrl_tx.send(MonitorCommand::Repaint(b'\r')).ok();
+                            }
+                            (KeyCode::Char('p'), KeyModifiers::CONTROL) => {
+                                ctrl_tx.send(MonitorCommand::SwitchMode).ok();
+                                break;
+                            }
+                            (KeyCode::Char('c'), KeyModifiers::CONTROL) => {
+                                ctrl_tx.send(MonitorCommand::Quit).ok();
+                                break;
+                            }
+                            (KeyCode::Enter, _) => {
+                                let _ = input_tx.send(line_buf.clone());
+
+                                if !line_buf.trim().is_empty() {
+                                    history.push(line_buf.clone());
+                                }
+                                history_idx = history.len();
+
+                                line_buf.clear();
+                                cursor_pos = 0;
+                                print!("\r\n");
+                                io::stdout().flush().ok();
+                            }
+                            (KeyCode::Backspace, _) => {
+                                if cursor_pos > 0 {
+                                    cursor_pos -= 1;
+                                    line_buf.remove(cursor_pos);
+                                    needs_redraw = true;
+                                }
+                            }
+                            (KeyCode::Delete, _) => {
+                                if cursor_pos < line_buf.len() {
+                                    line_buf.remove(cursor_pos);
+                                    needs_redraw = true;
+                                }
+                            }
+                            (KeyCode::Left, _) => {
+                                if cursor_pos > 0 {
+                                    cursor_pos -= 1;
+                                    needs_redraw = true;
+                                }
+                            }
+                            (KeyCode::Right, _) => {
+                                if cursor_pos < line_buf.len() {
+                                    cursor_pos += 1;
+                                    needs_redraw = true;
+                                }
+                            }
+                            (KeyCode::Up, _) => {
+                                if history_idx > 0 {
+                                    history_idx -= 1;
+                                    line_buf = history[history_idx].clone();
+                                    cursor_pos = line_buf.len();
+                                    needs_redraw = true;
+                                }
+                            }
+                            (KeyCode::Down, _) => {
+                                if history_idx < history.len() {
+                                    history_idx += 1;
+                                    if history_idx == history.len() {
+                                        line_buf.clear();
+                                    } else {
+                                        line_buf = history[history_idx].clone();
+                                    }
+                                    cursor_pos = line_buf.len();
+                                    needs_redraw = true;
+                                }
+                            }
+                            (KeyCode::Char(c), _) => {
+                                line_buf.insert(cursor_pos, c);
+                                cursor_pos += 1;
+                                needs_redraw = true;
+                            }
+                            _ => {}
+                        }
+
+                        // ── Dynamic Line Redrawing (Preserves Remote Prompts) ──
+                        if needs_redraw {
+                            // 1. Move cursor back to the start of our local typed input
+                            if old_cursor_pos > 0 {
+                                execute!(io::stdout(), cursor::MoveLeft(old_cursor_pos as u16))
+                                    .ok();
+                            }
+
+                            // 2. Overwrite ONLY the old typed text with spaces
+                            if old_len > 0 {
+                                print!("{:width$}", "", width = old_len);
+                                // Move back to the start of the local input again
+                                execute!(io::stdout(), cursor::MoveLeft(old_len as u16)).ok();
+                            }
+
+                            // 3. Print the newly updated buffer
+                            print!("{}", line_buf);
+
+                            // 4. Move the cursor back to the correct visual insertion point
+                            let offset = line_buf.len() - cursor_pos;
+                            if offset > 0 {
+                                execute!(io::stdout(), cursor::MoveLeft(offset as u16)).ok();
+                            }
+
                             io::stdout().flush().ok();
-                            ctrl_tx.send(MonitorCommand::Repaint(b'\r')).ok();
                         }
-                        (KeyCode::Char('p'), KeyModifiers::CONTROL) => {
-                            ctrl_tx.send(MonitorCommand::SwitchMode).ok();
-                            break;
-                        }
-                        (KeyCode::Char('c'), KeyModifiers::CONTROL) => {
-                            ctrl_tx.send(MonitorCommand::Quit).ok();
-                            break;
-                        }
-                        (KeyCode::Enter, _) => {
-                            let _ = input_tx.send(line_buf.clone());
-                            line_buf.clear();
-                            print!("\r\n");
-                            io::stdout().flush().ok();
-                        }
-                        (KeyCode::Backspace, _) => {
-                            line_buf.pop();
-                            print!("\x08 \x08");
-                            io::stdout().flush().ok();
-                        }
-                        (KeyCode::Char(c), _) => {
-                            line_buf.push(c);
-                            print!("{}", c);
-                            io::stdout().flush().ok();
-                        }
-                        _ => {}
-                    },
+                    }
                     Err(_) => break,
                     _ => {}
                 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -82,10 +82,15 @@ fn strip_log_prefixes(mut line: &str) -> &str {
                     line = line[lvl_end + 1..].trim_start();
                 }
 
-                if let Some(colon_idx) = line.find(": ")
-                    && !line[..colon_idx].contains(' ')
-                {
-                    line = line[colon_idx + 2..].trim_start();
+                if let Some(colon_idx) = line.find(": ") {
+                    let module_segment = &line[..colon_idx];
+                    if !module_segment.contains(' ')
+                        && module_segment
+                            .chars()
+                            .all(|c| c.is_alphanumeric() || c == '_')
+                    {
+                        line = line[colon_idx + 2..].trim_start();
+                    }
                 }
             }
         }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -63,11 +63,85 @@ impl SensorData {
     }
 }
 
+fn strip_log_prefixes(mut line: &str) -> &str {
+    line = line.trim();
+
+    if line.starts_with('[') {
+        if let Some(end_idx) = line.find(']') {
+            let inside = &line[1..end_idx];
+
+            if inside
+                .chars()
+                .all(|c| c.is_ascii_digit() || c == ':' || c == '.' || c == ',')
+            {
+                line = line[end_idx + 1..].trim_start();
+
+                if line.starts_with('<')
+                    && let Some(lvl_end) = line.find('>')
+                {
+                    line = line[lvl_end + 1..].trim_start();
+                }
+
+                if let Some(colon_idx) = line.find(": ")
+                    && !line[..colon_idx].contains(' ')
+                {
+                    line = line[colon_idx + 2..].trim_start();
+                }
+            }
+        }
+    } else {
+        let parts: Vec<&str> = line.split_whitespace().collect();
+        if parts.len() >= 2 {
+            let looks_like_time = parts[0].parse::<f64>().is_ok();
+
+            let clean_level =
+                parts[1].trim_matches(|c| c == '[' || c == ']' || c == '<' || c == '>');
+
+            let is_level = matches!(
+                clean_level,
+                "INFO"
+                    | "WARN"
+                    | "ERROR"
+                    | "DEBUG"
+                    | "TRACE"
+                    | "info"
+                    | "warn"
+                    | "error"
+                    | "debug"
+                    | "trace"
+            );
+
+            if looks_like_time
+                && is_level
+                && let Some(level_idx) = line.find(parts[1])
+            {
+                line = line[level_idx + parts[1].len()..].trim_start();
+
+                // 2. Strip defmt module paths and separators (`]`, `└─`, `├─`)
+                if let Some(bracket_idx) = line.find(']') {
+                    if !line[..bracket_idx].trim().contains(' ') {
+                        line = line[bracket_idx + 1..].trim_start();
+                    }
+                } else if let Some(tree_idx) = line.find("└─") {
+                    line = line[tree_idx + "└─".len()..].trim_start();
+                } else if let Some(tree_idx) = line.find("├─") {
+                    line = line[tree_idx + "├─".len()..].trim_start();
+                }
+            }
+        }
+    }
+
+    line
+}
+
 /// Entry point to parse a raw serial line into zero or more (sensor_name, value) pairs.
 pub fn parse_sensor_data(line: &str) -> Vec<(String, f64)> {
     // 1. Strip ANSI escape sequences (Colors) entirely from the line
     let clean_line = strip_ansi(line);
     let mut working_line = clean_line.trim();
+
+    // ── NEW: Strip defmt/RTOS timestamps before any parsing happens ──
+    working_line = strip_log_prefixes(working_line);
 
     // 2. Preprocess and strip metadata if it originates from a Zephyr logger
     working_line = strip_zephyr_headers(working_line);
@@ -76,6 +150,11 @@ pub fn parse_sensor_data(line: &str) -> Vec<(String, f64)> {
     if working_line.contains(',')
         && let Some(results) = parse_comma_separated(working_line)
     {
+        return results;
+    }
+
+    // 3.5 Try parsing space-separated key-value pairs
+    if let Some(results) = parse_space_separated_kv(working_line) {
         return results;
     }
 
@@ -178,6 +257,25 @@ fn parse_space_separated_numbers(line: &str) -> Option<Vec<(String, f64)>> {
             .enumerate()
             .map(|(i, v)| (format!("Channel {}", i), v))
             .collect();
+        Some(results)
+    } else {
+        None
+    }
+}
+
+/// Strategy 3.5: Handles space-separated Key:Value pairs (e.g., "ax:1.2 ay:3.4")
+fn parse_space_separated_kv(line: &str) -> Option<Vec<(String, f64)>> {
+    let parts: Vec<&str> = line.split_whitespace().collect();
+    let mut results = Vec::new();
+
+    for part in parts {
+        if let Some((name, val)) = parse_kv_split(part, ':').or_else(|| parse_kv_split(part, '=')) {
+            results.push((name.to_string(), val));
+        }
+    }
+
+    // Only return success if we actually found multiple valid key-value pairs
+    if results.len() > 1 {
         Some(results)
     } else {
         None

--- a/src/plotter.rs
+++ b/src/plotter.rs
@@ -1034,7 +1034,7 @@ pub fn run_plotter_mode(
                 state.sensor_scroll = state.sensor_scroll.min(max_scroll);
 
                 let mut scrollbar_state = ScrollbarState::default()
-                    .content_length(lines.len().saturating_sub(inner.height as usize))
+                    .content_length(max_scroll)
                     .position(state.sensor_scroll);
 
                 let para = Paragraph::new(lines).scroll((state.sensor_scroll as u16, 0));

--- a/src/plotter.rs
+++ b/src/plotter.rs
@@ -125,6 +125,7 @@ struct PlotterState {
     ratty_engines: Option<RattyGraphic<'static>>,
 
     show_help: bool,
+    sensor_scroll: usize,
 }
 
 const DISCARD_FIRST_LINES: usize = 3;
@@ -214,6 +215,7 @@ impl PlotterState {
             ratty_engines,
 
             show_help: false,
+            sensor_scroll: 0,
         }
     }
 
@@ -528,6 +530,13 @@ pub fn run_plotter_mode(
                             state.last_error = Some(format!("❌ Export failed: {}", e));
                         }
                     }
+                }
+
+                KeyCode::Up => {
+                    state.sensor_scroll = state.sensor_scroll.saturating_sub(1);
+                }
+                KeyCode::Down => {
+                    state.sensor_scroll = state.sensor_scroll.saturating_add(1);
                 }
 
                 _ => {}
@@ -1019,8 +1028,23 @@ pub fn run_plotter_mode(
                         Style::default().fg(Color::DarkGray),
                     )]));
                 }
-                let para = Paragraph::new(lines).wrap(Wrap { trim: false });
+
+                // Scrollbar state
+                let max_scroll = lines.len().saturating_sub(inner.height as usize);
+                state.sensor_scroll = state.sensor_scroll.min(max_scroll);
+
+                let mut scrollbar_state = ScrollbarState::default()
+                    .content_length(lines.len().saturating_sub(inner.height as usize))
+                    .position(state.sensor_scroll);
+
+                let para = Paragraph::new(lines).scroll((state.sensor_scroll as u16, 0));
                 f.render_widget(para, inner);
+
+                f.render_stateful_widget(
+                    Scrollbar::default().orientation(ScrollbarOrientation::VerticalRight),
+                    inner,
+                    &mut scrollbar_state,
+                );
             }
 
             // ── Status bar ────────────────────────────────────────────────────


### PR DESCRIPTION
- **Parser Enhancements:** Add `strip_log_prefixes` and `parse_space_separated_kv` to automatically handle `defmt`/RTOS log timestamps and module prefixes. This fixes the issue where timestamps were incorrectly identified as new sensor channels.
- **Plotter Legend UI:** Implement scrolling for the sensor legend block to prevent clipping when monitoring many sensors.
- **Interactive Scrolling:** Add vertical scrolling state to `PlotterState` and bind `Up`/`Down` arrow keys to navigate the sensor legend.
- **Scrollbar Integration:** Add a `Scrollbar` widget to the sensor legend block, using proportional `ScrollbarState` to reflect the actual scrollable content length.

Closes #97 (Hopefully)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes mis-parsing of `defmt`/RTOS timestamps and improves the TUI with a scrollable sensor legend plus readline-style input and history. Bumps `comchan` to 0.13.0.

- **New Features**
  - Scrollable sensor legend with vertical scrollbar; use Up/Down to navigate.
  - Readline-style local input: left/right editing, delete/backspace, and command history on Up/Down.
  - Parser supports space-separated key:value or key=value pairs.

- **Bug Fixes**
  - Parsing: Strip `defmt`/RTOS timestamps, levels, and module prefixes, and tighten module checks to avoid eating valid labels (fixes #97).
  - TUI: Preserve remote prompts, fix non-ASCII input panics during editing, and correct legend scrollbar math.

<sup>Written for commit dd47633cc0b59c98ad9558b0b93cb933e483ee1b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Vaishnav-Sabari-Girish/ComChan/pull/98?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

