### PR TITLE
fix(monitor): correct initial log indentation in raw mode

### DIFF
--- a/src/monitor.rs
+++ b/src/monitor.rs
@@ -397,19 +397,21 @@ pub fn run_normal_mode(
                         }
                     }
 
-                    println!(
-                        "\r\n{color_green}🔌 Connected to {} at {} baud{color_reset}",
+                    print!(
+                        "\r\n{color_green}🔌 Connected to {} at {} baud{color_reset}\r\n",
                         port_name, config.baud
                     );
                     if config.verbose {
-                        println!(
-                            "\r{color_blue}⚙️  Config: {} data bits, {} stop bits, {} parity, {} flow control{color_reset}",
+                        print!(
+                            "{color_blue}⚙️  Config: {} data bits, {} stop bits, {} parity, {} flow control{color_reset}\r\n",
                             config.data_bits, config.stop_bits, config.parity, config.flow_control
                         );
                         if let Some(log_path) = &config.log_file {
-                            println!("\r{color_blue} Logging to: {}{color_reset}", log_path);
+                            print!("{color_blue} Logging to: {}{color_reset}\r\n", log_path);
                         }
                     }
+
+                    io::stdout().flush().ok();
                     Some(p)
                 }
                 Err(_) => {


### PR DESCRIPTION
- Replace `println!` with `print!` and explicit `\r\n` for connection and configuration banners.
- Resolves an issue where the terminal in raw mode would not return the cursor to the left margin after printing the banner, causing the first incoming serial log (e.g., Zephyr boot messages) to be incorrectly indented.



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes incorrect indentation of the first serial log line in raw mode. Connection and config banners now use `print!` with explicit `\r\n` and flush stdout so the cursor returns to the left margin before device logs (e.g., Zephyr boot messages) start.

<sup>Written for commit 78e779b2a7eacc29d5d87565dff93f71c079c17a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Vaishnav-Sabari-Girish/ComChan/pull/101?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

