### PR TITLE
build: drastically reduce binary size via dependency trimming and LTO

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -538,12 +538,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "color_quant"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
-
-[[package]]
 name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -571,7 +565,7 @@ dependencies = [
 
 [[package]]
 name = "comchan"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "btleplug",
  "chrono",
@@ -1295,15 +1289,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd2e7510819d6fbf51a5545c8f922716ecfb14df168a3242f7d33e0239efe6a1"
 
 [[package]]
-name = "fdeflate"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c"
-dependencies = [
- "simd-adler32",
-]
-
-[[package]]
 name = "filedescriptor"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1598,16 +1583,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "gif"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80792593675e051cf94a4b111980da2ba60d4a83e43e0048c5693baab3977045"
-dependencies = [
- "color_quant",
- "weezl",
-]
-
-[[package]]
 name = "gimli"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1878,20 +1853,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "365a784774bb381e8c19edb91190a90d7f2625e057b55de2bc0f6b57bc779ff2"
 
 [[package]]
-name = "image"
-version = "0.24.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5690139d2f55868e080017335e4b94cb7414274c74f1669c84fb5feba2c9f69d"
-dependencies = [
- "bytemuck",
- "byteorder",
- "color_quant",
- "jpeg-decoder",
- "num-traits",
- "png",
-]
-
-[[package]]
 name = "indexmap"
 version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2036,12 +1997,6 @@ dependencies = [
  "quote",
  "syn 2.0.117",
 ]
-
-[[package]]
-name = "jpeg-decoder"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00810f1d8b74be64b13dbf3db89ac67740615d6c891f0e7b6179326533011a07"
 
 [[package]]
 name = "js-sys"
@@ -2794,14 +2749,11 @@ version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
 dependencies = [
- "chrono",
  "font-kit",
- "image",
  "lazy_static",
  "num-traits",
  "pathfinder_geometry",
  "plotters-backend",
- "plotters-bitmap",
  "plotters-svg",
  "ttf-parser",
  "wasm-bindgen",
@@ -2815,36 +2767,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a"
 
 [[package]]
-name = "plotters-bitmap"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72ce181e3f6bf82d6c1dc569103ca7b1bd964c60ba03d7e6cdfbb3e3eb7f7405"
-dependencies = [
- "gif",
- "image",
- "plotters-backend",
-]
-
-[[package]]
 name = "plotters-svg"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
 dependencies = [
  "plotters-backend",
-]
-
-[[package]]
-name = "png"
-version = "0.17.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82151a2fc869e011c153adc57cf2789ccb8d9906ce52c0b39a6b5697749d7526"
-dependencies = [
- "bitflags 1.3.2",
- "crc32fast",
- "fdeflate",
- "flate2",
- "miniz_oxide",
 ]
 
 [[package]]
@@ -3070,9 +2998,9 @@ dependencies = [
 
 [[package]]
 name = "ratatui-ratty"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a4628ffc4abd26ae6da794639f146c5f3922803a9ad9775054e957371a84dbe"
+checksum = "eddeba6ef95da4c2ddaadc743908a30ffe3ebfb4025f28b5bad49309246c5efb"
 dependencies = [
  "base64",
  "ratatui-core",
@@ -4126,12 +4054,6 @@ dependencies = [
  "js-sys",
  "wasm-bindgen",
 ]
-
-[[package]]
-name = "weezl"
-version = "0.1.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
 
 [[package]]
 name = "wezterm-bidi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "comchan"
-version = "0.13.0"
+version = "0.14.0"
 edition = "2024"
 authors = ["Vaishnav Sabari Girish <vaishnav.sabari.girish@gmail.com>"]
 license = "MIT"
@@ -30,11 +30,11 @@ futures = { version = "0.3.32", optional = true }
 inline_colorization = "0.1.6"
 inquire = { version = "0.9.4", optional = true }
 object = "0.39.1"
-plotters = "0.3.7"
+plotters = { version = "0.3.7", default-features = false, features = ["line_series", "svg_backend", "ttf"] }
 pretty-hex = "0.4.2"
 probe-rs = "0.31.0"
 ratatui = "0.30.1"
-ratatui-ratty = { version = "0.3.0", optional = true }
+ratatui-ratty = { version = "0.4.0", optional = true }
 ratatui-wireframe = { version = "0.7.0", path = "crates/ratatui-wireframe", features = ["ratty"] }
 serde = { version = "1.0", features = ["derive"] }
 serialport = "4.9"
@@ -50,7 +50,7 @@ members = [
 
 [profile.dist]
 inherits = "release"
-lto = "thin"
+lto = true
 
 [profile.release]
 opt-level = "z"     # Optimize for size (use "s" if "z" is too slow)


### PR DESCRIPTION
- Disabled default features for the `plotters` crate, retaining only `line_series`, `svg_backend`, and `ttf`. This completely removes heavy image-processing and bitmap dependencies (`image`, `png`, `jpeg-decoder`, `gif`, etc.) from the build tree.
- Updated the `[profile.dist]` configuration to use fat LTO (`lto = true`) instead of `"thin"`, ensuring aggressive cross-crate dead code elimination during release/binstall builds.
- Bumped `ratatui-ratty` dependency to version `0.4.0`.
- Bumped `comchan` package version to `0.14.0`.

Closes #99 


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cut the release binary size by trimming `plotters` features and enabling fat LTO for distribution builds. Closes #99.

- **Dependencies**
  - `plotters`: disabled default features; kept `line_series`, `svg_backend`, `ttf` to drop bitmap/image deps (`image`, `png`, `jpeg-decoder`, `gif`, etc.).
  - `ratatui-ratty` → `0.4.0`.
  - `comchan` crate version → `0.14.0`.

- **Refactors**
  - `[profile.dist]`: switched LTO from "thin" to fat (`lto = true`) for stronger cross-crate dead code elimination.

<sup>Written for commit 7507a34e6121358d3c170bd0dfb2718e9d48a052. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Vaishnav-Sabari-Girish/ComChan/pull/102?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

