### PR TITLE
build/add grimoire

### DIFF
--- a/Grimoire.toml
+++ b/Grimoire.toml
@@ -1,0 +1,78 @@
+version = "1"
+
+[sigil.hello]
+silent = true
+description = "Welcome message"
+language = "shell"
+run = "echo 'Thank you for installing ComChan'"
+
+[sigil.run]
+silent = true
+description = "Run ComChan"
+language = "shell"
+depends = ["hello"]
+run = "cargo run --features {{features}}"
+
+[sigil.run.args.features]
+type = "select"
+choices = [
+  "default",
+  "ratty",
+  "ble",
+  "ratty,ble"
+]
+default = "default"
+
+[sigil.build]
+silent = true
+description = "Build ComChan"
+language = "shell"
+run = "cargo build --features {{features}}"
+
+[sigil.build.args.features]
+type = "select"
+choices = [
+  "default",
+  "ratty",
+  "ble",
+  "ratty,ble"
+]
+default = "default"
+
+[sigil.run_release]
+silent = true
+description = "Run ComChan in release mode"
+language = "shell"
+depends = ["hello"]
+run = "cargo run --release --features {{features}}"
+
+[sigil.run_release.args.features]
+type = "select"
+choices = [
+  "default",
+  "ratty",
+  "ble",
+  "ratty,ble"
+]
+default = "default"
+
+[sigil.build_release]
+silent = true
+description = "Build ComChan in release mode"
+language = "shell"
+run = "cargo build --release --features {{features}}"
+
+[sigil.build_release.args.features]
+type = "select"
+choices = [
+  "default",
+  "ratty",
+  "ble",
+  "ratty,ble"
+]
+default = "default"
+
+[sigil.clean]
+description = "Clean build artifacts"
+silent = true
+run = "cargo clean"

--- a/Grimoire.toml
+++ b/Grimoire.toml
@@ -11,7 +11,7 @@ silent = true
 description = "Run ComChan"
 language = "shell"
 depends = ["hello"]
-run = "cargo run --features {{features}}"
+run = "cargo run --features {{features}} --"
 
 [sigil.run.args.features]
 type = "select"
@@ -44,7 +44,7 @@ silent = true
 description = "Run ComChan in release mode"
 language = "shell"
 depends = ["hello"]
-run = "cargo run --release --features {{features}}"
+run = "cargo run --release --features {{features}} --"
 
 [sigil.run_release.args.features]
 type = "select"

--- a/Grimoire.toml
+++ b/Grimoire.toml
@@ -6,28 +6,11 @@ description = "Welcome message"
 language = "shell"
 run = "echo 'Thank you for installing ComChan'"
 
-[sigil.run]
-silent = true
-description = "Run ComChan"
-language = "shell"
-depends = ["hello"]
-run = "cargo run --features {{features}} --"
-
-[sigil.run.args.features]
-type = "select"
-choices = [
-  "default",
-  "ratty",
-  "ble",
-  "ratty,ble"
-]
-default = "default"
-
 [sigil.build]
 silent = true
-description = "Build ComChan"
+description = "Build ComChan in release mode"
 language = "shell"
-run = "cargo build --features {{features}}"
+run = "cargo build --release --features {{features}}"
 
 [sigil.build.args.features]
 type = "select"
@@ -39,14 +22,13 @@ choices = [
 ]
 default = "default"
 
-[sigil.run_release]
+[sigil.run]
 silent = true
-description = "Run ComChan in release mode"
+description = "Run ComChan (Add the flags you require like --simulate)"
 language = "shell"
-depends = ["hello"]
 run = "cargo run --release --features {{features}} --"
 
-[sigil.run_release.args.features]
+[sigil.run.args.features]
 type = "select"
 choices = [
   "default",
@@ -56,13 +38,14 @@ choices = [
 ]
 default = "default"
 
-[sigil.build_release]
+[sigil.install]
 silent = true
-description = "Build ComChan in release mode"
+description = "Install ComChan to ~/.cargo/bin/"
 language = "shell"
-run = "cargo build --release --features {{features}}"
+depends = ["hello"]
+run = "cargo install --path . --features {{features}}"
 
-[sigil.build_release.args.features]
+[sigil.install.args.features]
 type = "select"
 choices = [
   "default",
@@ -71,6 +54,7 @@ choices = [
   "ratty,ble"
 ]
 default = "default"
+
 
 [sigil.clean]
 description = "Clean build artifacts"

--- a/README.md
+++ b/README.md
@@ -32,12 +32,14 @@ cargo install comchan
 # Install with Hardware-Accelerated 3D support (Ratty Terminal) and BLE
 cargo install comchan --features ratty,ble
 
+
 ```
 
 Verify the installation:
 
 ```bash
 comchan --version
+
 
 ```
 
@@ -59,6 +61,7 @@ yay -S comchan-ratty
 ## Using paru
 paru -S comchan-ratty
 
+
 ```
 
 ### The Binary
@@ -70,6 +73,7 @@ cargo binstall comchan
 # AUR 
 yay -S comchan-bin
 paru -S comchan-bin
+
 
 ```
 
@@ -85,6 +89,7 @@ paru -S comchan-bin
 
 ```bash
 elda i https://github.com/Vaishnav-Sabari-Girish/ComChan
+
 
 ```
 
@@ -103,7 +108,45 @@ git clone https://github.com/Vaishnav-Sabari-Girish/ComChan.git
 cd ComChan
 cargo run --release --features ble,ratty -- --version
 
+
 ```
+
+---
+
+## 🪄 Magic Workflow (Powered by Grimoire)
+
+ComChan uses [Grimoire](https://github.com/Vaishnav-Sabari-Girish/grimoire) as
+its official task runner to make building, running, and installing completely
+effortless. Grimoire provides interactive Terminal UI menus so you never have to
+memorize Cargo feature flags again!
+
+If you have Grimoire installed (`cargo install grim`), you can cast these spells
+(tasks) directly in the cloned repository:
+
+```bash
+# Compile the project (Interactive prompt for 'ratty' / 'ble' features)
+grim cast build     # You can also use grim run (cast and run are the same commands)
+
+# Run the project locally 
+# (Use the '--' separator to seamlessly pass flags like --simulate to ComChan)
+grim cast run -- --simulate
+
+# Install the binary directly to ~/.cargo/bin/ (Interactive feature prompt)
+grim cast install
+
+# Clean all build artifacts
+grim cast clean
+
+```
+
+To view all the commands, refer to the [`Grimoire.toml`](./Grimoire.toml) or
+just run
+
+```bash
+grim sigils   # Or grim list
+```
+
+---
 
 ## CLI Usage
 
@@ -126,6 +169,7 @@ Options:
   -V, --version                        Print version
   # ... (and many more)
 
+
 ```
 
 ---
@@ -141,6 +185,7 @@ ComChan supports streaming data wirelessly from BLE-enabled embedded devices
 # Start ComChan in BLE mode to scan and connect to a peripheral
 comchan --ble
 
+
 ```
 
 ComChan will scan for devices, prompt you to select your target, and
@@ -152,6 +197,7 @@ stream is active.
 
 ```bash
 comchan -p /dev/ttyUSB0 -r 115200
+
 
 ```
 
@@ -165,6 +211,7 @@ comchan -p /dev/ttyUSB0 /dev/ttyUSB1 -r 115200
 
 # Test it out using the built-in simulator!
 comchan --simulate -p mock1 mock2
+
 
 ```
 
@@ -183,6 +230,7 @@ directly from your microcontroller's memory via SWD.
 ```bash
 comchan --rtt --elf path/to/firmware.elf --chip nRF52840_xxAA
 
+
 ```
 
 ### Plotter & 3D Spatial Telemetry
@@ -192,6 +240,7 @@ Line Chart and the 3D Telemetry Dashboard.
 
 ```bash
 comchan --port /dev/ttyUSB0 --baud 115200 --plot
+
 
 ```
 

--- a/README.md
+++ b/README.md
@@ -128,8 +128,7 @@ If you have Grimoire installed (`cargo install grim`), you can cast these spells
 grim cast build     # You can also use grim run (cast and run are the same commands)
 
 # Run the project locally 
-# (Use the '--' separator to seamlessly pass flags like --simulate to ComChan)
-grim cast run -- --simulate
+grim cast run --simulate
 
 # Install the binary directly to ~/.cargo/bin/ (Interactive feature prompt)
 grim cast install


### PR DESCRIPTION
Integrate [Grimoire](https://github.com/Vaishnav-Sabari-Girish/grimoire) task runner and update documentation

- Add `Grimoire.toml` with interactive sigils (`build`, `run`, `install`, `clean`) to easily manage Cargo feature flag combinations (`ratty`, `ble`).
- Update `README.md` with a "Magic Workflow" section to guide users on using `grim` commands for a frictionless setup and installation.

Closes #100

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Integrates `Grimoire` as the task runner with interactive sigils to build, run, install, and clean using selectable Cargo features. Adds a `hello` welcome sigil and updates the README Magic Workflow, fixing examples by removing an extra `--`.

- **New Features**
  - Adds `Grimoire.toml` with sigils: `hello`, `build`, `run`, `install` (depends on `hello`), `clean`.
  - Interactive feature selection for `ratty` and `ble`; `grim cast` docs for build/run/install/clean.

- **Migration**
  - Optional: install `grim` via `cargo install grim` to use tasks.
  - No changes to existing `cargo` commands.

<sup>Written for commit a88f00d3d0a5b9a01c74d8eaee0bfa98b5ecec65. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Vaishnav-Sabari-Girish/ComChan/pull/103?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

